### PR TITLE
feat(sdk): expose the label each contender actually requested

### DIFF
--- a/packages/rs-sdk-ffi/src/contested_resource/queries/vote_state.rs
+++ b/packages/rs-sdk-ffi/src/contested_resource/queries/vote_state.rs
@@ -1,7 +1,10 @@
 use crate::types::SDKHandle;
 use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, DashSDKResultDataType};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::document::DocumentV0Getters;
 use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::dpp::voting::contender_structs::ContenderWithSerializedDocument;
+use dash_sdk::platform::{DataContract, Fetch};
 use dash_sdk::dpp::voting::vote_info_storage::contested_document_vote_poll_winner_info::ContestedDocumentVotePollWinnerInfo;
 use dash_sdk::dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
 use dash_sdk::drive::query::vote_poll_vote_state_query::ContestedDocumentVotePollDriveQuery;
@@ -235,6 +238,19 @@ fn get_contested_resource_vote_state(
                 }
                 // Add contenders
                 if result_type.has_documents() {
+                    // Decode each contender's document so callers get the
+                    // label the requester actually typed ("pizza") next to the
+                    // homograph-normalized index value ("p1zza"). Without this
+                    // a UI can only show the normalized form, which reads as a
+                    // typo to the person who submitted it.
+                    //
+                    // Best-effort: the contract fetch or a single decode
+                    // failing must not fail the whole query, so `label` is
+                    // simply absent for rows that could not be decoded and the
+                    // caller falls back to the normalized value.
+                    let contract: Option<DataContract> =
+                        DataContract::fetch(&sdk, contract_id).await.ok().flatten();
+
                     let contenders_json: Vec<String> = contenders.contenders
                         .iter()
                         .map(|(id, contender)| {
@@ -245,13 +261,36 @@ fn get_contested_resource_vote_state(
                                 r#""document":null"#.to_string()
                             };
 
+                            let label_json = contract
+                                .as_ref()
+                                .and_then(|contract| {
+                                    let doc_type = contract
+                                        .document_type_for_name(document_type_name_str)
+                                        .ok()?;
+                                    let decoded = contender
+                                        .try_to_contender(doc_type, sdk.version())
+                                        .ok()?;
+                                    let label = decoded
+                                        .document()
+                                        .as_ref()?
+                                        .get("label")?
+                                        .as_str()?
+                                        .to_string();
+                                    Some(format!(
+                                        r#","label":{}"#,
+                                        serde_json::to_string(&label).ok()?
+                                    ))
+                                })
+                                .unwrap_or_default();
+
                             let vote_count = contender.vote_tally().unwrap_or(0);
 
                             format!(
-                                r#"{{"identity_id":"{}","vote_count":{},{}}}"#,
+                                r#"{{"identity_id":"{}","vote_count":{},{}{}}}"#,
                                 bs58::encode(id.as_bytes()).into_string(),
                                 vote_count,
-                                document_json
+                                document_json,
+                                label_json
                             )
                         })
                         .collect();

--- a/packages/rs-sdk-ffi/src/contested_resource/queries/vote_state.rs
+++ b/packages/rs-sdk-ffi/src/contested_resource/queries/vote_state.rs
@@ -4,11 +4,11 @@ use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::document::DocumentV0Getters;
 use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::dpp::voting::contender_structs::ContenderWithSerializedDocument;
-use dash_sdk::platform::{DataContract, Fetch};
 use dash_sdk::dpp::voting::vote_info_storage::contested_document_vote_poll_winner_info::ContestedDocumentVotePollWinnerInfo;
 use dash_sdk::dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
 use dash_sdk::drive::query::vote_poll_vote_state_query::ContestedDocumentVotePollDriveQuery;
 use dash_sdk::platform::FetchMany;
+use dash_sdk::platform::{DataContract, Fetch};
 use dash_sdk::query_types::Contenders;
 use std::ffi::{c_char, c_void, CStr, CString};
 

--- a/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
+++ b/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
@@ -545,6 +545,33 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_non_resolved_contests_for_identity(
                     });
                 }
 
+                // Ordered, de-duplicated requested labels. Derived here so the
+                // display policy lives in one place rather than being
+                // re-implemented by each language binding.
+                let mut requested_labels: Vec<*mut c_char> = Vec::new();
+                let mut seen_labels: Vec<String> = Vec::new();
+                for contender in &contenders {
+                    if contender.label.is_null() {
+                        continue;
+                    }
+                    let label = CStr::from_ptr(contender.label)
+                        .to_string_lossy()
+                        .into_owned();
+                    if label.is_empty() || seen_labels.contains(&label) {
+                        continue;
+                    }
+                    if let Ok(c_label) = CString::new(label.clone()) {
+                        seen_labels.push(label);
+                        requested_labels.push(c_label.into_raw());
+                    }
+                }
+                let requested_label_count = requested_labels.len();
+                let requested_labels_ptr = if requested_labels.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    Box::into_raw(requested_labels.into_boxed_slice()) as *mut *mut c_char
+                };
+
                 let contender_count = contenders.len();
                 let contenders_ptr = if contenders.is_empty() {
                     std::ptr::null_mut()
@@ -556,6 +583,8 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_non_resolved_contests_for_identity(
                 let contest_info_c = DashSDKContestInfo {
                     contenders: contenders_ptr,
                     contender_count,
+                    requested_labels: requested_labels_ptr,
+                    requested_label_count,
                     abstain_votes: contest_info.contenders.abstain_vote_tally.unwrap_or(0),
                     lock_votes: contest_info.contenders.lock_vote_tally.unwrap_or(0),
                     end_time: contest_info.end_time,
@@ -668,6 +697,33 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
                     });
                 }
 
+                // Ordered, de-duplicated requested labels. Derived here so the
+                // display policy lives in one place rather than being
+                // re-implemented by each language binding.
+                let mut requested_labels: Vec<*mut c_char> = Vec::new();
+                let mut seen_labels: Vec<String> = Vec::new();
+                for contender in &contenders {
+                    if contender.label.is_null() {
+                        continue;
+                    }
+                    let label = CStr::from_ptr(contender.label)
+                        .to_string_lossy()
+                        .into_owned();
+                    if label.is_empty() || seen_labels.contains(&label) {
+                        continue;
+                    }
+                    if let Ok(c_label) = CString::new(label.clone()) {
+                        seen_labels.push(label);
+                        requested_labels.push(c_label.into_raw());
+                    }
+                }
+                let requested_label_count = requested_labels.len();
+                let requested_labels_ptr = if requested_labels.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    Box::into_raw(requested_labels.into_boxed_slice()) as *mut *mut c_char
+                };
+
                 let contender_count = contenders.len();
                 let contenders_ptr = if contenders.is_empty() {
                     std::ptr::null_mut()
@@ -679,6 +735,8 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
                 let contest_info_c = DashSDKContestInfo {
                     contenders: contenders_ptr,
                     contender_count,
+                    requested_labels: requested_labels_ptr,
+                    requested_label_count,
                     abstain_votes: contest_info.contenders.abstain_vote_tally.unwrap_or(0),
                     lock_votes: contest_info.contenders.lock_vote_tally.unwrap_or(0),
                     end_time: contest_info.end_time,

--- a/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
+++ b/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
@@ -1,5 +1,8 @@
 //! FFI bindings for contested DPNS username queries
 
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::document::DocumentV0Getters;
+use dash_sdk::dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
@@ -488,6 +491,13 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_non_resolved_contests_for_identity(
 
     match result {
         Ok(names_with_contest_info) => {
+            // Baked-in system contract: no network round trip, and it is the
+            // schema these documents were written against.
+            let platform_version = sdk.version();
+            let dpns_domain_type = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+                .ok()
+                .and_then(|contract| contract.document_type_cloned_for_name("domain").ok());
+
             let count = names_with_contest_info.len();
             let mut names = Vec::with_capacity(count);
 
@@ -512,9 +522,25 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_non_resolved_contests_for_identity(
                     // Extract actual vote tally from ContenderWithSerializedDocument
                     let vote_count = votes.vote_tally().unwrap_or(0);
 
+                    // The requester's own spelling ("pizza"), which the
+                    // normalized contest name ("p1zza") does not preserve.
+                    // Null when the document can't be decoded — callers fall
+                    // back to the normalized name rather than guessing.
+                    let c_label = dpns_domain_type
+                        .as_ref()
+                        .and_then(|doc_type| {
+                            let decoded = votes
+                                .try_to_contender(doc_type.as_ref(), platform_version)
+                                .ok()?;
+                            let label = decoded.document().as_ref()?.get("label")?.as_str()?;
+                            CString::new(label).ok().map(|s| s.into_raw())
+                        })
+                        .unwrap_or(std::ptr::null_mut());
+
                     contenders.push(DashSDKContender {
                         identity_id: c_id,
                         vote_count,
+                        label: c_label,
                     });
                 }
 
@@ -587,6 +613,13 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
 
     match result {
         Ok(names_with_contest_info) => {
+            // Baked-in system contract: no network round trip, and it is the
+            // schema these documents were written against.
+            let platform_version = sdk.version();
+            let dpns_domain_type = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+                .ok()
+                .and_then(|contract| contract.document_type_cloned_for_name("domain").ok());
+
             let count = names_with_contest_info.len();
             let mut names = Vec::with_capacity(count);
 
@@ -611,9 +644,25 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
                     // Extract actual vote tally from ContenderWithSerializedDocument
                     let vote_count = votes.vote_tally().unwrap_or(0);
 
+                    // The requester's own spelling ("pizza"), which the
+                    // normalized contest name ("p1zza") does not preserve.
+                    // Null when the document can't be decoded — callers fall
+                    // back to the normalized name rather than guessing.
+                    let c_label = dpns_domain_type
+                        .as_ref()
+                        .and_then(|doc_type| {
+                            let decoded = votes
+                                .try_to_contender(doc_type.as_ref(), platform_version)
+                                .ok()?;
+                            let label = decoded.document().as_ref()?.get("label")?.as_str()?;
+                            CString::new(label).ok().map(|s| s.into_raw())
+                        })
+                        .unwrap_or(std::ptr::null_mut());
+
                     contenders.push(DashSDKContender {
                         identity_id: c_id,
                         vote_count,
+                        label: c_label,
                     });
                 }
 

--- a/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
+++ b/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
@@ -494,9 +494,10 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_non_resolved_contests_for_identity(
             // Baked-in system contract: no network round trip, and it is the
             // schema these documents were written against.
             let platform_version = sdk.version();
-            let dpns_domain_type = load_system_data_contract(SystemDataContract::DPNS, platform_version)
-                .ok()
-                .and_then(|contract| contract.document_type_cloned_for_name("domain").ok());
+            let dpns_domain_type =
+                load_system_data_contract(SystemDataContract::DPNS, platform_version)
+                    .ok()
+                    .and_then(|contract| contract.document_type_cloned_for_name("domain").ok());
 
             let count = names_with_contest_info.len();
             let mut names = Vec::with_capacity(count);
@@ -616,9 +617,10 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
             // Baked-in system contract: no network round trip, and it is the
             // schema these documents were written against.
             let platform_version = sdk.version();
-            let dpns_domain_type = load_system_data_contract(SystemDataContract::DPNS, platform_version)
-                .ok()
-                .and_then(|contract| contract.document_type_cloned_for_name("domain").ok());
+            let dpns_domain_type =
+                load_system_data_contract(SystemDataContract::DPNS, platform_version)
+                    .ok()
+                    .and_then(|contract| contract.document_type_cloned_for_name("domain").ok());
 
             let count = names_with_contest_info.len();
             let mut names = Vec::with_capacity(count);

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -1047,6 +1047,14 @@ pub struct DashSDKContestInfo {
     pub contenders: *mut DashSDKContender,
     /// Number of contenders
     pub contender_count: usize,
+    /// The distinct labels the contenders requested, in contender order and
+    /// already de-duplicated — `["pizza", "p1zza"]` for a contest normalized to
+    /// `"p1zza"`. Derived here rather than by the caller so display policy has
+    /// one home. Null/zero when no contender document could be decoded; callers
+    /// fall back to the normalized contest name.
+    pub requested_labels: *mut *mut c_char,
+    /// Number of entries in `requested_labels`.
+    pub requested_label_count: usize,
     /// Abstain vote tally (0 if none)
     pub abstain_votes: u32,
     /// Lock vote tally (0 if none)
@@ -1146,6 +1154,34 @@ unsafe fn free_contender_array(contenders: *mut DashSDKContender, count: usize) 
     let _ = Vec::from_raw_parts(contenders, count, count);
 }
 
+/// Release a heap array of C strings allocated by this SDK.
+///
+/// # Safety
+/// - `strings` must be null, or a pointer from `Box::into_raw` over a boxed
+///   slice of exactly `count` `CString::into_raw` pointers.
+unsafe fn free_string_array(strings: *mut *mut c_char, count: usize) {
+    if strings.is_null() || count == 0 {
+        return;
+    }
+    for i in 0..count {
+        dash_sdk_string_free(*strings.add(i));
+    }
+    let _ = Vec::from_raw_parts(strings, count, count);
+}
+
+/// Release everything a `DashSDKContestInfo` owns, without freeing the struct
+/// itself — it is embedded in `DashSDKContestedName` in some paths and boxed in
+/// others. Single home for "what does a contest info own", so a new field is
+/// one edit rather than one per destructor.
+///
+/// # Safety
+/// - `info` must point to a live `DashSDKContestInfo` whose buffers were
+///   allocated by this SDK and not yet freed.
+unsafe fn free_contest_info_fields(info: *mut DashSDKContestInfo) {
+    free_contender_array((*info).contenders, (*info).contender_count);
+    free_string_array((*info).requested_labels, (*info).requested_label_count);
+}
+
 /// Free contest info structure
 ///
 /// # Safety
@@ -1158,8 +1194,8 @@ pub unsafe extern "C" fn dash_sdk_contest_info_free(info: *mut DashSDKContestInf
         return;
     }
 
-    let info = Box::from_raw(info);
-    free_contender_array(info.contenders, info.contender_count);
+    let mut info = Box::from_raw(info);
+    free_contest_info_fields(&mut *info);
 }
 
 /// Free a contested name structure
@@ -1174,14 +1210,11 @@ pub unsafe extern "C" fn dash_sdk_contested_name_free(name: *mut DashSDKConteste
         return;
     }
 
-    let name = Box::from_raw(name);
+    let mut name = Box::from_raw(name);
     dash_sdk_string_free(name.name);
 
     // Free contest info contents (but not the struct itself as it's embedded)
-    free_contender_array(
-        name.contest_info.contenders,
-        name.contest_info.contender_count,
-    );
+    free_contest_info_fields(&mut name.contest_info);
 }
 
 /// Free a contested names list
@@ -1203,10 +1236,7 @@ pub unsafe extern "C" fn dash_sdk_contested_names_list_free(list: *mut DashSDKCo
             dash_sdk_string_free((*name).name);
 
             // Free contest info contents
-            free_contender_array(
-                (*name).contest_info.contenders,
-                (*name).contest_info.contender_count,
-            );
+            free_contest_info_fields(&mut (*name).contest_info);
         }
         let _ = Vec::from_raw_parts(list.names, list.count, list.count);
     }
@@ -1455,7 +1485,7 @@ unsafe fn dash_sdk_public_key_destroy_ptr(handle: *mut IdentityPublicKeyHandle) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::CString;
+    use std::ffi::{CStr, CString};
 
     /// Verifies that `DashSDKResult::success_binary` now correctly shrinks
     /// Vec capacity to match len via `into_boxed_slice()`, so that the free
@@ -1713,6 +1743,28 @@ mod tests {
     }
 
     unsafe fn make_contest_info(contenders: Vec<DashSDKContender>) -> DashSDKContestInfo {
+        // Mirror the producers: the ordered-unique labels are a separate
+        // allocation the destructors must also release.
+        let mut labels: Vec<*mut c_char> = Vec::new();
+        let mut seen: Vec<String> = Vec::new();
+        for c in &contenders {
+            if c.label.is_null() {
+                continue;
+            }
+            let l = CStr::from_ptr(c.label).to_string_lossy().into_owned();
+            if l.is_empty() || seen.contains(&l) {
+                continue;
+            }
+            seen.push(l.clone());
+            labels.push(CString::new(l).unwrap().into_raw());
+        }
+        let label_count = labels.len();
+        let labels_ptr = if labels.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            Box::into_raw(labels.into_boxed_slice()) as *mut *mut c_char
+        };
+
         let count = contenders.len();
         let ptr = if count == 0 {
             std::ptr::null_mut()
@@ -1722,6 +1774,8 @@ mod tests {
         DashSDKContestInfo {
             contenders: ptr,
             contender_count: count,
+            requested_labels: labels_ptr,
+            requested_label_count: label_count,
             abstain_votes: 1,
             lock_votes: 2,
             end_time: 1_700_000_000_000,
@@ -1781,6 +1835,33 @@ mod tests {
                 ]),
             };
             dash_sdk_contested_name_free(Box::into_raw(Box::new(name)));
+        }
+    }
+
+    #[test]
+    fn contest_info_free_releases_requested_labels() {
+        unsafe {
+            // Two distinct spellings plus a repeat and an undecodable row:
+            // the ordered-unique array holds two entries, all of which the
+            // destructor must release.
+            let info = make_contest_info(vec![
+                make_contender("Ab1", Some("pizza")),
+                make_contender("Cd2", Some("p1zza")),
+                make_contender("Ef3", Some("pizza")),
+                make_contender("Gh4", None),
+            ]);
+            assert_eq!(info.requested_label_count, 2);
+            dash_sdk_contest_info_free(Box::into_raw(Box::new(info)));
+        }
+    }
+
+    #[test]
+    fn contest_info_has_no_labels_when_nothing_decoded() {
+        unsafe {
+            let info = make_contest_info(vec![make_contender("Ab1", None)]);
+            assert_eq!(info.requested_label_count, 0);
+            assert!(info.requested_labels.is_null());
+            dash_sdk_contest_info_free(Box::into_raw(Box::new(info)));
         }
     }
 

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -1109,8 +1109,41 @@ pub unsafe extern "C" fn dash_sdk_contender_free(contender: *mut DashSDKContende
         return;
     }
 
-    let contender = Box::from_raw(contender);
-    dash_sdk_string_free(contender.identity_id);
+    let mut contender = Box::from_raw(contender);
+    free_contender_fields(&mut *contender);
+}
+
+/// Release the heap strings owned by one contender.
+///
+/// Every destructor that owns contenders funnels through this: the fields were
+/// duplicated across four free paths, and adding `label` to the struct without
+/// updating all of them leaked one allocation per decoded contender on three of
+/// them. A single helper makes the next added field a one-line change.
+///
+/// # Safety
+/// - `contender` must point to a live `DashSDKContender` whose strings were
+///   allocated by this SDK and not yet freed.
+unsafe fn free_contender_fields(contender: *mut DashSDKContender) {
+    dash_sdk_string_free((*contender).identity_id);
+    // Null whenever the contender document could not be decoded;
+    // `dash_sdk_string_free` is a no-op on null.
+    dash_sdk_string_free((*contender).label);
+}
+
+/// Free the contender array owned by a `DashSDKContestInfo`, including each
+/// contender's strings.
+///
+/// # Safety
+/// - `contenders` must be either null or a pointer obtained from
+///   `Box::into_raw` over a boxed slice of exactly `count` contenders.
+unsafe fn free_contender_array(contenders: *mut DashSDKContender, count: usize) {
+    if contenders.is_null() || count == 0 {
+        return;
+    }
+    for i in 0..count {
+        free_contender_fields(contenders.add(i));
+    }
+    let _ = Vec::from_raw_parts(contenders, count, count);
 }
 
 /// Free contest info structure
@@ -1126,13 +1159,7 @@ pub unsafe extern "C" fn dash_sdk_contest_info_free(info: *mut DashSDKContestInf
     }
 
     let info = Box::from_raw(info);
-    if !info.contenders.is_null() && info.contender_count > 0 {
-        for i in 0..info.contender_count {
-            let contender = info.contenders.add(i);
-            dash_sdk_string_free((*contender).identity_id);
-        }
-        let _ = Vec::from_raw_parts(info.contenders, info.contender_count, info.contender_count);
-    }
+    free_contender_array(info.contenders, info.contender_count);
 }
 
 /// Free a contested name structure
@@ -1151,17 +1178,10 @@ pub unsafe extern "C" fn dash_sdk_contested_name_free(name: *mut DashSDKConteste
     dash_sdk_string_free(name.name);
 
     // Free contest info contents (but not the struct itself as it's embedded)
-    if !name.contest_info.contenders.is_null() && name.contest_info.contender_count > 0 {
-        for i in 0..name.contest_info.contender_count {
-            let contender = name.contest_info.contenders.add(i);
-            dash_sdk_string_free((*contender).identity_id);
-        }
-        let _ = Vec::from_raw_parts(
-            name.contest_info.contenders,
-            name.contest_info.contender_count,
-            name.contest_info.contender_count,
-        );
-    }
+    free_contender_array(
+        name.contest_info.contenders,
+        name.contest_info.contender_count,
+    );
 }
 
 /// Free a contested names list
@@ -1183,22 +1203,10 @@ pub unsafe extern "C" fn dash_sdk_contested_names_list_free(list: *mut DashSDKCo
             dash_sdk_string_free((*name).name);
 
             // Free contest info contents
-            if !(*name).contest_info.contenders.is_null()
-                && (*name).contest_info.contender_count > 0
-            {
-                for j in 0..(*name).contest_info.contender_count {
-                    let contender = (*name).contest_info.contenders.add(j);
-                    dash_sdk_string_free((*contender).identity_id);
-                    // Null for contenders whose document could not be decoded;
-                    // `dash_sdk_string_free` tolerates null.
-                    dash_sdk_string_free((*contender).label);
-                }
-                let _ = Vec::from_raw_parts(
-                    (*name).contest_info.contenders,
-                    (*name).contest_info.contender_count,
-                    (*name).contest_info.contender_count,
-                );
-            }
+            free_contender_array(
+                (*name).contest_info.contenders,
+                (*name).contest_info.contender_count,
+            );
         }
         let _ = Vec::from_raw_parts(list.names, list.count, list.count);
     }
@@ -1681,6 +1689,114 @@ mod tests {
 
             assert!(result.error.is_null());
             assert!(result.data.is_null());
+        }
+    }
+
+    // MARK: contender destructors
+    //
+    // These run under Miri/ASan in CI if enabled, but even without a leak
+    // checker they pin the shape that regressed: `label` was added to
+    // `DashSDKContender` and only one of the four free paths was updated, so
+    // three public destructors leaked one allocation per decoded contender.
+    // Every destructor now funnels through `free_contender_fields`.
+
+    /// Build a heap contender the way the DPNS producers do.
+    unsafe fn make_contender(id: &str, label: Option<&str>) -> DashSDKContender {
+        DashSDKContender {
+            identity_id: CString::new(id).unwrap().into_raw(),
+            vote_count: 7,
+            label: match label {
+                Some(l) => CString::new(l).unwrap().into_raw(),
+                None => std::ptr::null_mut(),
+            },
+        }
+    }
+
+    unsafe fn make_contest_info(contenders: Vec<DashSDKContender>) -> DashSDKContestInfo {
+        let count = contenders.len();
+        let ptr = if count == 0 {
+            std::ptr::null_mut()
+        } else {
+            Box::into_raw(contenders.into_boxed_slice()) as *mut DashSDKContender
+        };
+        DashSDKContestInfo {
+            contenders: ptr,
+            contender_count: count,
+            abstain_votes: 1,
+            lock_votes: 2,
+            end_time: 1_700_000_000_000,
+            has_winner: false,
+        }
+    }
+
+    #[test]
+    fn contender_free_releases_label() {
+        unsafe {
+            let contender = Box::into_raw(Box::new(make_contender("Ab1", Some("pizza"))));
+            dash_sdk_contender_free(contender);
+        }
+    }
+
+    #[test]
+    fn contender_free_tolerates_absent_label() {
+        unsafe {
+            let contender = Box::into_raw(Box::new(make_contender("Ab1", None)));
+            dash_sdk_contender_free(contender);
+        }
+    }
+
+    #[test]
+    fn contender_free_is_null_safe() {
+        unsafe { dash_sdk_contender_free(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn contest_info_free_releases_every_contender_label() {
+        unsafe {
+            let info = make_contest_info(vec![
+                make_contender("Ab1", Some("pizza")),
+                make_contender("Cd2", Some("p1zza")),
+                make_contender("Ef3", None),
+            ]);
+            dash_sdk_contest_info_free(Box::into_raw(Box::new(info)));
+        }
+    }
+
+    #[test]
+    fn contest_info_free_handles_no_contenders() {
+        unsafe {
+            let info = make_contest_info(vec![]);
+            dash_sdk_contest_info_free(Box::into_raw(Box::new(info)));
+        }
+    }
+
+    #[test]
+    fn contested_name_free_releases_labels() {
+        unsafe {
+            let name = DashSDKContestedName {
+                name: CString::new("p1zza").unwrap().into_raw(),
+                contest_info: make_contest_info(vec![
+                    make_contender("Ab1", Some("pizza")),
+                    make_contender("Cd2", None),
+                ]),
+            };
+            dash_sdk_contested_name_free(Box::into_raw(Box::new(name)));
+        }
+    }
+
+    #[test]
+    fn contested_names_list_free_releases_labels() {
+        unsafe {
+            let names = vec![DashSDKContestedName {
+                name: CString::new("p1zza").unwrap().into_raw(),
+                contest_info: make_contest_info(vec![make_contender("Ab1", Some("pizza"))]),
+            }];
+            let count = names.len();
+            let list = DashSDKContestedNamesList {
+                names: Box::into_raw(names.into_boxed_slice()) as *mut DashSDKContestedName,
+                count,
+            };
+            dash_sdk_contested_names_list_free(Box::into_raw(Box::new(list)));
         }
     }
 }

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -1032,6 +1032,12 @@ pub struct DashSDKContender {
     pub identity_id: *mut c_char,
     /// Vote count for this contender
     pub vote_count: u32,
+    /// The label this contender actually requested ("pizza"), decoded from
+    /// their `domain` document — the contest itself is keyed by the
+    /// homograph-normalized form ("p1zza"). Null when the document could not
+    /// be decoded; callers fall back to the normalized name rather than
+    /// guessing a spelling.
+    pub label: *mut c_char,
 }
 
 /// Represents contest information for a DPNS name
@@ -1183,6 +1189,9 @@ pub unsafe extern "C" fn dash_sdk_contested_names_list_free(list: *mut DashSDKCo
                 for j in 0..(*name).contest_info.contender_count {
                     let contender = (*name).contest_info.contenders.add(j);
                     dash_sdk_string_free((*contender).identity_id);
+                    // Null for contenders whose document could not be decoded;
+                    // `dash_sdk_string_free` tolerates null.
+                    dash_sdk_string_free((*contender).label);
                 }
                 let _ = Vec::from_raw_parts(
                     (*name).contest_info.contenders,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
@@ -1094,6 +1094,16 @@ extension SDK {
                             contenderDict["identifier"] = String(cString: idPtr)
                         }
                         contenderDict["votes"] = "ResourceVote { vote_choice: TowardsIdentity, strength: \(contender.vote_count) }"
+                        // The spelling this contender actually requested
+                        // ("pizza"), where the contest key is the normalized
+                        // form ("p1zza"). Absent when the FFI could not decode
+                        // their document. Prefer the typed
+                        // `dpnsActiveContests` / `dpnsContestsForIdentity`,
+                        // which also give the tally as an integer.
+                        if let labelPtr = contender.label {
+                            let label = String(cString: labelPtr)
+                            if !label.isEmpty { contenderDict["label"] = label }
+                        }
 
                         contenders.append(contenderDict)
                     }
@@ -1225,6 +1235,16 @@ extension SDK {
                             contenderDict["identifier"] = String(cString: idPtr)
                         }
                         contenderDict["votes"] = "ResourceVote { vote_choice: TowardsIdentity, strength: \(contender.vote_count) }"
+                        // The spelling this contender actually requested
+                        // ("pizza"), where the contest key is the normalized
+                        // form ("p1zza"). Absent when the FFI could not decode
+                        // their document. Prefer the typed
+                        // `dpnsActiveContests` / `dpnsContestsForIdentity`,
+                        // which also give the tally as an integer.
+                        if let labelPtr = contender.label {
+                            let label = String(cString: labelPtr)
+                            if !label.isEmpty { contenderDict["label"] = label }
+                        }
 
                         contenders.append(contenderDict)
                     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
@@ -77,6 +77,20 @@ public struct DPNSContest: Sendable, Identifiable, Equatable {
     contenders.reduce(UInt32(0)) { $0 &+ $1.voteTally } &+ abstainVotes &+ lockVotes
   }
 
+  /// The spellings the contenders actually requested, de-duplicated and in
+  /// contender order — `["pizza", "p1zza"]` for a contest normalized to
+  /// `"p1zza"`.
+  ///
+  /// Empty when no contender document could be decoded; render
+  /// ``normalizedLabel`` in that case rather than inventing a spelling.
+  public var requestedLabels: [String] {
+    var seen = Set<String>()
+    return contenders.compactMap { contender in
+      guard let label = contender.displayLabel, seen.insert(label).inserted else { return nil }
+      return label
+    }
+  }
+
   /// The contender with the highest tally, or `nil` when there are none.
   /// Ties resolve to the first in FFI order — callers that care about tie
   /// display should inspect ``contenders`` directly.
@@ -86,24 +100,26 @@ public struct DPNSContest: Sendable, Identifiable, Equatable {
 }
 
 /// One contender for a contested DPNS label.
-///
-/// - Note: The contender's label exactly as *they* requested it is not
-///   exposed. Platform returns it only inside the serialized `domain`
-///   document, which the FFI hands over as opaque hex; decoding it needs the
-///   contract's document-type schema and is not done on the Swift side.
-///   Render ``identityId`` (truncated) alongside the contest's normalized
-///   label instead.
 public struct DPNSContender: Sendable, Identifiable, Equatable {
   /// Base58 identity id of the contender.
   public let identityId: String
   /// Masternode voting weight cast towards this contender.
   public let voteTally: UInt32
+  /// The label exactly as this contender typed it — `"pizza"`, where the
+  /// contest's normalized form is `"p1zza"`.
+  ///
+  /// Decoded by the FFI from the contender's `domain` document. `nil` when the
+  /// query did not carry documents (the active-contest listing does not), or
+  /// when that document could not be decoded — show ``identityId`` or the
+  /// contest's normalized label rather than inventing a spelling.
+  public let displayLabel: String?
 
   public var id: String { identityId }
 
-  public init(identityId: String, voteTally: UInt32) {
+  public init(identityId: String, voteTally: UInt32, displayLabel: String? = nil) {
     self.identityId = identityId
     self.voteTally = voteTally
+    self.displayLabel = displayLabel
   }
 }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
@@ -50,6 +50,16 @@ public struct DPNSContest: Sendable, Identifiable, Equatable {
   public let lockVotes: UInt32
   /// Contenders and their tallies, in the order the FFI returned them.
   public let contenders: [DPNSContender]
+  /// The distinct spellings the contenders requested, in contender order —
+  /// `["pizza", "p1zza"]` for a contest normalized to `"p1zza"`.
+  ///
+  /// Ordered and de-duplicated **in Rust** and decoded here verbatim: which
+  /// spellings to show is display policy, and the SDK is a thin bridge, not a
+  /// place for policy loops.
+  ///
+  /// Empty when no contender document could be decoded; render
+  /// ``normalizedLabel`` in that case rather than inventing a spelling.
+  public let requestedLabels: [String]
 
   public var id: String { normalizedLabel }
 
@@ -59,7 +69,8 @@ public struct DPNSContest: Sendable, Identifiable, Equatable {
     hasWinner: Bool,
     abstainVotes: UInt32,
     lockVotes: UInt32,
-    contenders: [DPNSContender]
+    contenders: [DPNSContender],
+    requestedLabels: [String] = []
   ) {
     self.normalizedLabel = normalizedLabel
     self.endTime = endTime
@@ -67,6 +78,7 @@ public struct DPNSContest: Sendable, Identifiable, Equatable {
     self.abstainVotes = abstainVotes
     self.lockVotes = lockVotes
     self.contenders = contenders
+    self.requestedLabels = requestedLabels
   }
 
   /// Total masternode voting weight recorded so far across contenders,
@@ -75,20 +87,6 @@ public struct DPNSContest: Sendable, Identifiable, Equatable {
   /// count of nodes.
   public var totalVotes: UInt32 {
     contenders.reduce(UInt32(0)) { $0 &+ $1.voteTally } &+ abstainVotes &+ lockVotes
-  }
-
-  /// The spellings the contenders actually requested, de-duplicated and in
-  /// contender order — `["pizza", "p1zza"]` for a contest normalized to
-  /// `"p1zza"`.
-  ///
-  /// Empty when no contender document could be decoded; render
-  /// ``normalizedLabel`` in that case rather than inventing a spelling.
-  public var requestedLabels: [String] {
-    var seen = Set<String>()
-    return contenders.compactMap { contender in
-      guard let label = contender.displayLabel, seen.insert(label).inserted else { return nil }
-      return label
-    }
   }
 
   /// The contender with the highest tally, or `nil` when there are none.
@@ -109,9 +107,9 @@ public struct DPNSContender: Sendable, Identifiable, Equatable {
   /// contest's normalized form is `"p1zza"`.
   ///
   /// Decoded by the FFI from the contender's `domain` document. `nil` when the
-  /// query did not carry documents (the active-contest listing does not), or
-  /// when that document could not be decoded — show ``identityId`` or the
-  /// contest's normalized label rather than inventing a spelling.
+  /// label data was unavailable or decoding that contender's document failed —
+  /// show ``identityId`` or the contest's normalized label rather than
+  /// inventing a spelling.
   public let displayLabel: String?
 
   public var id: String { identityId }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -139,6 +139,16 @@ extension SDK {
         }
       }
 
+      // Ordered and de-duplicated on the Rust side; copied verbatim.
+      var requestedLabels: [String] = []
+      if info.requested_label_count > 0, let labelsPtr = info.requested_labels {
+        requestedLabels.reserveCapacity(Int(info.requested_label_count))
+        for labelIndex in 0..<Int(info.requested_label_count) {
+          guard let labelPtr = labelsPtr[labelIndex] else { continue }
+          requestedLabels.append(String(cString: labelPtr))
+        }
+      }
+
       contests.append(
         DPNSContest(
           normalizedLabel: normalizedLabel,
@@ -150,7 +160,8 @@ extension SDK {
           hasWinner: info.has_winner,
           abstainVotes: info.abstain_votes,
           lockVotes: info.lock_votes,
-          contenders: contenders))
+          contenders: contenders,
+          requestedLabels: requestedLabels))
     }
 
     return contests.sorted { $0.normalizedLabel < $1.normalizedLabel }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -94,10 +94,14 @@ extension SDK {
         for contenderIndex in 0..<Int(info.contender_count) {
           let contender = contendersPtr[contenderIndex]
           guard let idPtr = contender.identity_id else { continue }
+          // `label` is null when the FFI could not decode that contender's
+          // document — a missing display name, not a reason to drop the row.
+          let displayLabel = contender.label.map { String(cString: $0) }
           contenders.append(
             DPNSContender(
               identityId: String(cString: idPtr),
-              voteTally: contender.vote_count))
+              voteTally: contender.vote_count,
+              displayLabel: displayLabel?.isEmpty == false ? displayLabel : nil))
         }
       }
 
@@ -182,7 +186,11 @@ extension SDK {
   /// `{"abstain_vote_tally":N,"lock_vote_tally":N,
   ///   "winner_info":"NoWinner"|"Locked"|{"type":"WonByIdentity","identity_id":"…"},
   ///   "block_info":{"height":…,"core_height":…,"timestamp":…},
-  ///   "contenders":[{"identity_id":"…","vote_count":N,"document":"hex"|null}]}`
+  ///   "contenders":[{"identity_id":"…","vote_count":N,"document":"hex"|null,
+  ///                  "label":"pizza"}]}`
+  ///
+  /// `label` is the requester's own spelling, decoded FFI-side from the
+  /// contender document; it is omitted when that decode was not possible.
   ///
   /// `winner_info` and `block_info` are absent while voting is open; when
   /// either is present the poll has finished (see ``DPNSContestOutcome``).
@@ -197,7 +205,10 @@ extension SDK {
       .compactMap { entry in
         guard let identityId = entry["identity_id"] as? String else { return nil }
         let tally = (entry["vote_count"] as? NSNumber)?.uint32Value ?? 0
-        return DPNSContender(identityId: identityId, voteTally: tally)
+        // `label` is absent when the FFI could not decode the document; that
+        // is a missing display name, not a reason to drop the contender.
+        let label = (entry["label"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        return DPNSContender(identityId: identityId, voteTally: tally, displayLabel: label)
       }
 
     let outcome: DPNSContestOutcome = {

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -70,10 +70,44 @@ extension SDK {
     guard let handle = handle else {
       throw SDKError.invalidState("SDK not initialized")
     }
-
     guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(handle, limit) else {
       throw SDKError.internalError("Failed to fetch contested DPNS usernames")
     }
+    return Self.consumeContestedNamesList(listPtr)
+  }
+
+  /// The open contests **this identity is contending in** — the "how are my
+  /// own username requests doing" view, where ``dpnsActiveContests(limit:)`` is
+  /// the network-wide one.
+  ///
+  /// - Parameters:
+  ///   - identityId: Base58 identity id.
+  ///   - limit: Maximum contests to return.
+  public func dpnsContestsForIdentity(
+    identityId: String,
+    limit: UInt32 = 100
+  ) throws -> [DPNSContest] {
+    guard let handle = handle else {
+      throw SDKError.invalidState("SDK not initialized")
+    }
+    guard let listPtr = identityId.withCString({ idPtr in
+      dash_sdk_dpns_get_non_resolved_contests_for_identity(handle, idPtr, limit)
+    }) else {
+      throw SDKError.internalError("Failed to fetch contested DPNS usernames for identity")
+    }
+    return Self.consumeContestedNamesList(listPtr)
+  }
+
+  /// Copy a `DashSDKContestedNamesList` into Swift values and free it.
+  ///
+  /// Shared by both list queries — they return the same C shape, and a second
+  /// hand-rolled reader would be one more place for the ownership rules and
+  /// the null-label handling to drift.
+  ///
+  /// Takes ownership: the list is freed before returning, on every path.
+  private static func consumeContestedNamesList(
+    _ listPtr: UnsafeMutablePointer<DashSDKContestedNamesList>
+  ) -> [DPNSContest] {
     defer { dash_sdk_contested_names_list_free(listPtr) }
 
     let list = listPtr.pointee

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DPNSContestDecoderTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DPNSContestDecoderTests.swift
@@ -253,7 +253,10 @@ final class DPNSContestDecoderTests: XCTestCase {
     XCTAssertNil(state.contenders.first?.displayLabel)
   }
 
-  func testRequestedLabelsDedupeAndPreserveOrder() {
+  func testRequestedLabelsAreCarriedVerbatim() {
+    // Ordering and de-duplication happen in Rust (see the `requested_labels`
+    // derivation and its tests in rs-sdk-ffi); Swift only carries the result,
+    // so this pins that the value survives the model boundary unchanged.
     let contest = DPNSContest(
       normalizedLabel: "p1zza",
       endTime: nil,
@@ -263,13 +266,13 @@ final class DPNSContestDecoderTests: XCTestCase {
       contenders: [
         DPNSContender(identityId: "Ab1", voteTally: 3, displayLabel: "pizza"),
         DPNSContender(identityId: "Cd2", voteTally: 1, displayLabel: "p1zza"),
-        DPNSContender(identityId: "Ef3", voteTally: 1, displayLabel: "pizza"),
-      ])
+      ],
+      requestedLabels: ["pizza", "p1zza"])
 
     XCTAssertEqual(contest.requestedLabels, ["pizza", "p1zza"])
   }
 
-  func testRequestedLabelsEmptyWhenNothingDecoded() {
+  func testRequestedLabelsDefaultEmptyWhenNothingDecoded() {
     let contest = DPNSContest(
       normalizedLabel: "p1zza",
       endTime: nil,

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DPNSContestDecoderTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DPNSContestDecoderTests.swift
@@ -16,8 +16,10 @@ final class DPNSContestDecoderTests: XCTestCase {
     SDK.decodeVoteState(json: json, normalizedLabel: label)
   }
 
-  private func contender(_ id: String, _ votes: Int) -> [String: Any] {
-    ["identity_id": id, "vote_count": votes, "document": NSNull()]
+  private func contender(_ id: String, _ votes: Int, label: String? = nil) -> [String: Any] {
+    var entry: [String: Any] = ["identity_id": id, "vote_count": votes, "document": NSNull()]
+    if let label { entry["label"] = label }
+    return entry
   }
 
   // MARK: - Outcome branches
@@ -223,6 +225,61 @@ final class DPNSContestDecoderTests: XCTestCase {
 
     XCTAssertNil(contest.leadingContender)
     XCTAssertEqual(contest.totalVotes, 0)
+  }
+
+  // MARK: - Display labels
+
+  func testContenderDisplayLabelIsDecoded() {
+    // The FFI decodes each contender's `domain` document and hands back the
+    // spelling they typed; the contest itself is keyed by the normalized form.
+    let state = decode([
+      "contenders": [contender("Ab1", 3, label: "pizza"), contender("Cd2", 1, label: "p1zza")],
+    ])
+
+    XCTAssertEqual(state.contenders.map(\.displayLabel), ["pizza", "p1zza"])
+  }
+
+  func testMissingLabelIsNilNotEmpty() {
+    // A contender whose document could not be decoded has no display name —
+    // callers fall back to the identity id rather than showing a blank.
+    let state = decode(["contenders": [contender("Ab1", 3)]])
+
+    XCTAssertNil(state.contenders.first?.displayLabel)
+  }
+
+  func testEmptyLabelIsTreatedAsAbsent() {
+    let state = decode(["contenders": [contender("Ab1", 3, label: "")]])
+
+    XCTAssertNil(state.contenders.first?.displayLabel)
+  }
+
+  func testRequestedLabelsDedupeAndPreserveOrder() {
+    let contest = DPNSContest(
+      normalizedLabel: "p1zza",
+      endTime: nil,
+      hasWinner: false,
+      abstainVotes: 0,
+      lockVotes: 0,
+      contenders: [
+        DPNSContender(identityId: "Ab1", voteTally: 3, displayLabel: "pizza"),
+        DPNSContender(identityId: "Cd2", voteTally: 1, displayLabel: "p1zza"),
+        DPNSContender(identityId: "Ef3", voteTally: 1, displayLabel: "pizza"),
+      ])
+
+    XCTAssertEqual(contest.requestedLabels, ["pizza", "p1zza"])
+  }
+
+  func testRequestedLabelsEmptyWhenNothingDecoded() {
+    let contest = DPNSContest(
+      normalizedLabel: "p1zza",
+      endTime: nil,
+      hasWinner: false,
+      abstainVotes: 0,
+      lockVotes: 0,
+      contenders: [DPNSContender(identityId: "Ab1", voteTally: 3)])
+
+    XCTAssertTrue(contest.requestedLabels.isEmpty,
+                  "callers must fall back to the normalized label, not guess one")
   }
 
   // MARK: - Vote poll coordinates


### PR DESCRIPTION
## Why

DPNS keys a contest by the **homograph-normalized** label, so any UI that renders what Platform returns shows `p1zza` where the people involved typed `pizza`. That reads as a typo to the very users whose username is being voted on.

It cannot be fixed client-side: normalization maps `o`→`0` and `i`/`l`→`1`, which is lossy and ambiguous, so a client that tried to reverse it would invent a name nobody asked for.

The spelling was already on the wire the whole time. Each contender's `domain` document carries a `label` field, and both contested-resource queries were handing that document back **without reading it** — as opaque hex in the generic vote-state JSON, and not at all in the DPNS list.

## What

- **`dash_sdk_contested_resource_get_vote_state`** decodes each contender via `try_to_contender` against the **queried** contract's document type (kept generic, not DPNS-pinned) and adds `"label"` to each contender object.
- **`DashSDKContender`** gains a `label` C string, populated in `dash_sdk_dpns_get_contested_non_resolved_usernames` and `dash_sdk_dpns_get_contested_usernames_by_identity` from the **baked-in DPNS system contract** (`load_system_data_contract`) — a local load, no extra network round trip. Freed alongside `identity_id` in `dash_sdk_contested_names_list_free`.
- **Swift:** `DPNSContender.displayLabel`, plus `DPNSContest.requestedLabels` (de-duplicated, contender order) for the case where contenders typed *different* spellings that normalize to the same value — which is precisely what a contest is.

## Honesty of the fallback

Decoding is best-effort at every step. A contract fetch that fails, or a single document that will not decode, leaves `label` null for that row rather than failing the query; callers fall back to the normalized label or the identity id. **Nothing is ever synthesized from the normalized form.**

## Breaking change

`DashSDKContender` gains a field, so the generated C header changes and consumers must rebuild the xcframework. Done and verified here for both slices (`ios-arm64`, `ios-arm64-simulator`).

## Testing

- `cargo check -p rs-sdk-ffi` clean.
- `SwiftDashSDKTests/DPNSContestDecoderTests`: **24/24 pass** against the rebuilt framework — 5 new cases covering a decoded label, a missing label (nil, not empty), an empty label treated as absent, `requestedLabels` de-duplication and ordering, and the all-undecodable case asserting callers get an empty list to fall back from rather than a guess.
- Consumed by dashpay/dashwallet-ios#923, which builds clean against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DPNS contested-name results now include each contender’s requested name when available.
  * Added `requestedLabels` to provide unique contender labels in voting order.
  * Added identity-specific retrieval for active DPNS contests.
* **Bug Fixes**
  * Missing, empty, or invalid labels no longer prevent contest results from loading.
  * Improved safe cleanup of contender data across contest responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->