### PR TITLE
fix(swift-sdk): stop applying the account derivation path twice

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Account.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Account.swift
@@ -20,16 +20,31 @@ public class Account {
 
     // MARK: - Derivation (account-based)
 
-    /// Derive a private key (WIF) using this account and a master xpriv derived from the given path.
+    /// Derive a private key (WIF) at `index` under this account.
+    ///
+    /// The account's own derivation path is applied by the FFI:
+    /// `account_derive_private_key_as_wif_at` → `derive_xpriv_from_master_xpriv`,
+    /// which resolves `Account::derivation_path()` — the FULL path from the
+    /// wallet master (e.g. `m/9'/5'/3'/1'` for provider voting keys). So this
+    /// hands it the wallet **master** and takes no path argument.
+    ///
+    /// It previously accepted a `masterPath` and pre-derived it, applying the
+    /// account path twice: a caller passing the account root got the key at
+    /// `m/9'/5'/3'/1'/9'/5'/3'/1'/index` instead of `m/9'/5'/3'/1'/index`.
+    /// Nothing failed locally — the key was well-formed and deterministic, just
+    /// not the account's key at that index. That is only detectable against
+    /// something holding the real one: a masternode vote signed with it is
+    /// rejected as having no voter identity, since the voter identity is
+    /// derived from the signing key's own hash160.
+    ///
     /// - Parameters:
-    ///   - wallet: The parent wallet used to derive the master extended private key
-    ///   - masterPath: The account root derivation path (e.g., "m/9'/5'/3'/1'")
+    ///   - wallet: The parent wallet, used for its master extended private key
     ///   - index: The child index to derive (e.g., 0 for the first key)
     /// - Returns: The private key encoded as WIF
-    public func derivePrivateKeyWIF(wallet: Wallet, masterPath: String, index: UInt32) throws -> String {
+    public func derivePrivateKeyWIF(wallet: Wallet, index: UInt32) throws -> String {
         var error = FFIError()
-        // Derive master extended private key for this account root
-        let masterPtr = masterPath.withCString { pathCStr in
+        // "m" parses to the empty derivation path — the master key itself.
+        let masterPtr = "m".withCString { pathCStr in
             wallet_derive_extended_private_key(wallet.ffiHandle, pathCStr, &error)
         }
 

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/AccountDerivationPathTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/AccountDerivationPathTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+
+@testable import SwiftDashSDK
+
+/// `Account.derivePrivateKeyWIF(wallet:index:)` must apply the account's
+/// derivation path exactly once.
+///
+/// The FFI resolves `Account::derivation_path()` itself — the full path from
+/// the wallet master — so the wrapper has to hand it the master. It used to
+/// take a `masterPath`, pre-derive that, and pass the result, which applied the
+/// account path twice: provider voting keys came back from
+/// `m/9'/5'/3'/1'/9'/5'/3'/1'/index` instead of `m/9'/5'/3'/1'/index`.
+///
+/// Nothing failed locally when that happened. The key was well-formed and
+/// derived deterministically, so it round-tripped through WIF parsing and
+/// signing without complaint — it simply wasn't the account's key at that
+/// index. Only a counterparty holding the real key could tell: a masternode
+/// vote signed with it is rejected as having no voter identity, because the
+/// voter identity is derived from the signing key's own hash160.
+///
+/// So these pin account-based derivation against the explicit DIP-3 path,
+/// which is the thing the doubling silently broke.
+final class AccountDerivationPathTests: XCTestCase {
+    /// Standard BIP39 test vector, matching the other wallet tests here.
+    private let mnemonic =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+    private func assertAccountDerivationMatchesPath(
+        accountType: AccountType,
+        pathPrefix: String,
+        network: Network,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let wallet = try Wallet(mnemonic: mnemonic, network: network)
+        let account = try wallet.getAccount(type: accountType)
+
+        // Indexes beyond 0 matter: the doubled path agreed with nothing, but a
+        // single wrong level could still coincide at index 0 in principle.
+        for index in [UInt32(0), 1, 19] {
+            let viaAccount = try account.derivePrivateKeyWIF(wallet: wallet, index: index)
+            let viaPath = try wallet.derivePrivateKey(path: "\(pathPrefix)/\(index)")
+            XCTAssertEqual(
+                viaAccount, viaPath,
+                """
+                account-based derivation at index \(index) disagrees with \
+                \(pathPrefix)/\(index) — the account path is being applied the \
+                wrong number of times
+                """,
+                file: file, line: line)
+        }
+    }
+
+    func testProviderVotingKeysDeriveAtTheDIP3Path() throws {
+        try assertAccountDerivationMatchesPath(
+            accountType: .providerVotingKeys,
+            pathPrefix: "m/9'/5'/3'/1'",
+            network: .mainnet)
+    }
+
+    func testProviderOwnerKeysDeriveAtTheDIP3Path() throws {
+        try assertAccountDerivationMatchesPath(
+            accountType: .providerOwnerKeys,
+            pathPrefix: "m/9'/5'/3'/2'",
+            network: .mainnet)
+    }
+
+    /// The account resolves its own path, including coin type, so testnet must
+    /// land on `1'` without the caller saying so.
+    func testProviderVotingKeysUseTheTestnetCoinType() throws {
+        try assertAccountDerivationMatchesPath(
+            accountType: .providerVotingKeys,
+            pathPrefix: "m/9'/1'/3'/1'",
+            network: .testnet)
+    }
+
+    /// The specific regression: deriving against the account root rather than
+    /// the master must NOT reproduce account-based derivation. If these ever
+    /// match, the wrapper has gone back to pre-deriving the account path.
+    func testDoubledAccountPathIsNotWhatWeDerive() throws {
+        let wallet = try Wallet(mnemonic: mnemonic, network: .mainnet)
+        let account = try wallet.getAccount(type: .providerVotingKeys)
+
+        let correct = try account.derivePrivateKeyWIF(wallet: wallet, index: 19)
+        let doubled = try wallet.derivePrivateKey(path: "m/9'/5'/3'/1'/9'/5'/3'/1'/19")
+        XCTAssertNotEqual(
+            correct, doubled,
+            "account-based derivation is applying the account path twice again")
+    }
+}


### PR DESCRIPTION
## The bug

`Account.derivePrivateKeyWIF` returned keys from the wrong derivation path.

`account_derive_private_key_as_wif_at` → `derive_xpriv_from_master_xpriv` resolves `Account::derivation_path()` itself — the **full** path from the wallet master (`m/9'/5'/3'/1'` for provider voting keys, `…/2'` for owner) — so it must be handed the master:

```rust
let path = self.derivation_path()?;        // m/9'/5'/3'/1'
master_xpriv.derive_priv(&secp, &path)     // applied to whatever you pass
```

The Swift wrapper instead took a `masterPath`, pre-derived it, and passed the result. The account path was therefore applied **twice**:

```
m/9'/5'/3'/1'/9'/5'/3'/1'/index      instead of      m/9'/5'/3'/1'/index
```

Every caller hit it, because the parameter's own doc said to pass the account root (`"m/9'/5'/3'/1'"`).

## Why it went unnoticed

Nothing failed locally. The derived key was well-formed and deterministic, so it round-tripped through WIF parsing, address rendering and signing without complaint. It just wasn't the account's key at that index — only a counterparty holding the real key could tell.

That counterparty turned out to be Platform. A masternode vote is signed with the voting key, and the voter identity is `SHA256(pro_tx_hash ‖ hash160(voting pubkey))` — derived from the signing key's own hash. The wallet matched a node's registered voting address in its address pool (correct, that pool comes from the account xpub), then signed with a key from a different branch, so it asked Platform for an identity that had never existed. Platform answered `Public key 0 doesn't exist`, and after #4333 made that diagnostic, `No voting identity exists on Platform for masternode …`.

Confirmed arithmetically against a real device failure: the identity in the error matched neither `SHA256(protx ‖ h160(registered address))` nor its byte-reversed variant, proving the address the signer used was not the registered one.

## The fix

Hand the FFI the wallet master and drop the parameter. It is removed rather than corrected because its name and documentation both said "account root" — the API was wrong by default, and the only caller took the trap.

## Blast radius

`account_derive_private_key_as_wif_at` / `derivePrivateKeyWIF` has exactly **one** caller across the SDK and dashwallet-ios: the masternode key deriver. Identity and DPNS transitions sign through the platform-wallet identity signer in Rust and never touch this path, which is why document creates and identity operations were unaffected.

Two user-visible consequences, both fixed by this:
- masternode votes could not be cast at all
- the Masternode Keys screen displayed **wrong** owner/voting private keys — anyone who copied one out got a key from the doubled path

## Testing

New `AccountDerivationPathTests` pins account-based derivation against the explicit DIP-3 path:

- voting (`m/9'/5'/3'/1'`) and owner (`m/9'/5'/3'/2'`) keys at indexes 0, 1 and 19
- testnet coin type (`m/9'/1'/3'/1'`), since the account resolves its own network
- an explicit guard that the doubled path is *not* what we derive

Verified these **fail** with the old behaviour restored (4/4 failing) and **pass** with the fix (4/4), so they genuinely cover the regression rather than merely passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected wallet private-key derivation to consistently apply the account path once.
  * Simplified the key derivation API by removing the manual master-path parameter.

* **Tests**
  * Added coverage for mainnet and testnet account derivation paths.
  * Added validation for voting and owner keys, multiple indexes, and duplicate path prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->