### PR TITLE
chore(swift-sdk): remove Account.derivePrivateKeyWIF

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Account.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Account.swift
@@ -1,7 +1,24 @@
 import Foundation
 import DashSDKFFI
 
-/// Swift wrapper for a wallet account
+/// Owns a key-wallet account's FFI handle for as long as the caller holds it.
+///
+/// Deliberately exposes no account-specific operations: it exists so
+/// `Wallet.getAccount(type:)` can report whether an account exists (and create
+/// it as a side effect), with the handle freed on deinit.
+///
+/// Key derivation is NOT done here. It carried a
+/// `derivePrivateKeyWIF(wallet:masterPath:index:)` that asked callers for the
+/// account root path while the FFI applies the account's own path itself, so
+/// the path was applied twice and every derived key came from the wrong
+/// branch — silently, since the keys were well-formed. Derive instead through:
+///
+///   * `ManagedPlatformWallet.providerKeyAtIndex(kind:index:includePrivate:)`
+///     for the masternode provider families, which resolves the DIP-3 path
+///     Rust-side and cross-checks the seed-derived key against the account
+///     xpub before returning it, or
+///   * `Wallet.derivePrivateKey(path:)` for an explicit full path, where there
+///     is no implicit path to apply twice.
 public class Account {
     private let handle: OpaquePointer
     private weak var wallet: Wallet?
@@ -15,51 +32,4 @@ public class Account {
         account_free(handle)
     }
 
-    // The account-specific functionality would be implemented here
-    // For now, this is a placeholder that manages the FFI handle lifecycle
-
-    // MARK: - Derivation (account-based)
-
-    /// Derive a private key (WIF) using this account and a master xpriv derived from the given path.
-    /// - Parameters:
-    ///   - wallet: The parent wallet used to derive the master extended private key
-    ///   - masterPath: The account root derivation path (e.g., "m/9'/5'/3'/1'")
-    ///   - index: The child index to derive (e.g., 0 for the first key)
-    /// - Returns: The private key encoded as WIF
-    public func derivePrivateKeyWIF(wallet: Wallet, masterPath: String, index: UInt32) throws -> String {
-        var error = FFIError()
-        // Derive master extended private key for this account root
-        let masterPtr = masterPath.withCString { pathCStr in
-            wallet_derive_extended_private_key(wallet.ffiHandle, pathCStr, &error)
-        }
-
-        defer {
-            if error.message != nil {
-                error_message_free(error.message)
-            }
-            if let m = masterPtr {
-                extended_private_key_free(m)
-            }
-        }
-
-        guard let master = masterPtr else {
-            throw KeyWalletError(ffiError: error)
-        }
-
-        // Derive child private key as WIF at the given index
-        let wifPtr = account_derive_private_key_as_wif_at(self.handle, master, index, &error)
-
-        defer {
-            if error.message != nil {
-                error_message_free(error.message)
-            }
-        }
-
-        guard let ptr = wifPtr else {
-            throw KeyWalletError(ffiError: error)
-        }
-        let wif = String(cString: ptr)
-        string_free(ptr)
-        return wif
-    }
 }


### PR DESCRIPTION
Replaces #4334, which fixed this function. Deleting it is better now that nothing calls it.

## Why it's unused

#4338 moves the secp256k1 provider families (masternode owner / voting keys) onto `providerKeyAtIndex`. After it, `Account.derivePrivateKeyWIF` has **zero callers** — in platform (including the example app) and in dashwallet-ios.

## Why delete rather than fix

It applied the account derivation path twice: it asked callers for the account root path, while `account_derive_private_key_as_wif_at` → `derive_xpriv_from_master_xpriv` resolves `Account::derivation_path()` itself. So every owner/voting key came from

```
m/9'/5'/3'/1'/9'/5'/3'/1'/index      instead of      m/9'/5'/3'/1'/index
```

Nothing failed locally — the keys were well-formed and deterministic, and round-tripped through WIF parsing and signing without complaint. It surfaced only as Platform rejecting masternode votes as having no voter identity, because the voter identity is derived from the signing key's own hash160.

Fixing it (#4334) would have kept the last of the parallel derivation path #4338 exists to consolidate — and kept the variant *without* the seed-vs-xpub cross-check, watch-only support, or address that `providerKeyAtIndex` provides. The ambiguity was the bug: called on an account, taking a wallet, with the relationship between the account's own path and the passed key implicit. Even corrected, the next reader has to re-derive why `"m"` is right. Deleting removes the question instead of documenting the answer.

## Replacements

| need | use |
|---|---|
| masternode provider keys | `ManagedPlatformWallet.providerKeyAtIndex(kind:index:includePrivate:)` — DIP-3 path resolved Rust-side, seed cross-checked against the account xpub, works for watch-only |
| an explicit path | `Wallet.derivePrivateKey(path:)` — full path in, key out; no implicit path to apply twice |

`Account`'s doc now points at both, and describes what the type actually is: a handle whose lifetime `Wallet.getAccount(type:)` uses to report that an account exists (and create it as a side effect). That is its one remaining caller.

## Coverage

No regression. #4334's Swift tests pinned the DIP-3 paths, but #4338's Rust tests pin the same paths at the layer that derives them — plus the watch-only case the Swift tests never reached, which is what the app actually runs.

## Testing

- dashwallet-ios builds clean against this branch (the only real consumer)
- no `derivePrivateKeyWIF` definition or call site remains in either repo

Depends on #4338 landing first, since that removes the last caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the account-level private key derivation API.
  - Private key derivation is no longer performed through account objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->