### PR TITLE
feat(sdk): add transport feature to dapi-grpc for types-only consumers

### DIFF
--- a/.github/workflows/tests-rs-nightly-long-running.yml
+++ b/.github/workflows/tests-rs-nightly-long-running.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [dash-sdk, rs-dapi-client, rs-dapi, dapi-grpc, dpp, drive-abci]
+        package:
+          [dash-sdk, rs-dapi-client, rs-dapi, dapi-grpc, dpp, drive-abci, drive-proof-verifier]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -193,6 +193,30 @@ jobs:
           cargo install cargo-machete 2>/dev/null || true
           cargo machete
 
+      # The transport-free cut is how embedders with their own networking
+      # (Dash Core's platform GUI, explorers) consume verification: feature
+      # unification hides transport regressions in whole-workspace builds, so
+      # check the standalone graphs and assert the networking stack stays out
+      # of the proof-verification tree (native) and out of wasm builds.
+      - name: Check transport-free feature cut
+        run: |
+          cargo check -p dapi-grpc --no-default-features --features core,platform,client --locked
+          cargo check -p drive-proof-verifier --locked
+          for banned in hyper rustls tower; do
+            if cargo tree -p drive-proof-verifier -e normal -i "$banned" 2>/dev/null | grep -q .; then
+              echo "::error::$banned leaked into drive-proof-verifier's dependency tree"
+              exit 1
+            fi
+          done
+          for banned in hyper rustls tower mio; do
+            for wasm_package in dash-sdk wasm-sdk; do
+              if cargo tree -p "$wasm_package" --target wasm32-unknown-unknown -e normal -i "$banned" 2>/dev/null | grep -q .; then
+                echo "::error::$banned leaked into $wasm_package's wasm32 dependency tree"
+                exit 1
+              fi
+            done
+          done
+
       - name: Detect immutable structure changes
         if: github.event_name == 'pull_request'
         run: |

--- a/packages/dapi-grpc/Cargo.toml
+++ b/packages/dapi-grpc/Cargo.toml
@@ -26,12 +26,30 @@ tenderdash-proto = []
 # Client support.
 client = ["platform"]
 
+# Networked tonic client: `connect()` on generated clients, TLS roots.
+# Deliberately NOT in the default set: cargo features are not target-scoped,
+# so a default-on transport would force tonic's transport stack onto wasm32
+# consumers riding defaults, where it does not build. Without this feature
+# the crate provides message types and transport-generic client stubs only.
+# Tonic's codegen graph still includes tokio-stream and a minimal Tokio
+# slice, but its hyper/rustls transport stack is not enabled. Native
+# networked consumers enable this explicitly (rs-dapi-client does so through
+# its non-wasm dependency); the wasm codegen path never emits `connect()`.
+transport = [
+  "tonic/channel",
+  "tonic/transport",
+  "tonic/tls-native-roots",
+  "tonic/tls-webpki-roots",
+  "tonic/tls-ring",
+]
+
 # Build tonic server code. Includes all client features and adds server-specific dependencies.
 server = [
   "platform",
   "tenderdash-proto/server",
   "client",
   "drive",
+  "transport",
   "tonic/router",
 ]
 
@@ -55,14 +73,7 @@ tonic = { version = "0.14.2", features = ["codegen"], default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tonic = { version = "0.14.2", features = [
-  "codegen",
-  "channel",
-  "transport",
-  "tls-native-roots",
-  "tls-webpki-roots",
-  "tls-ring",
-], default-features = false }
+tonic = { version = "0.14.2", features = ["codegen"], default-features = false }
 
 [build-dependencies]
 tonic-prost-build = { version = "0.14.2" }

--- a/packages/dapi-grpc/build.rs
+++ b/packages/dapi-grpc/build.rs
@@ -69,6 +69,7 @@ fn generate_code(typ: ImplType, output_base: &Path) {
 
     println!("cargo:rerun-if-changed=./protos");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_SERDE");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TRANSPORT");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
     println!("cargo:rerun-if-env-changed=DAPI_GRPC_OUT_DIR");
 }
@@ -416,15 +417,23 @@ enum ImplType {
 impl ImplType {
     // Configure the builder based on the implementation type.
     pub fn configure(&self, builder: Builder) -> Builder {
+        // The `transport` cargo feature controls whether generated clients get
+        // the `connect()` convenience impls over tonic's own channel. Without
+        // it, clients are still generated but stay generic over the caller's
+        // transport. Never enabled for wasm32, where tonic transport does not
+        // build. Note: cfg!(target_arch) in a build script reflects the HOST,
+        // so the target must be read from CARGO_CFG_TARGET_ARCH.
+        let transport = std::env::var("CARGO_FEATURE_TRANSPORT").is_ok()
+            && std::env::var("CARGO_CFG_TARGET_ARCH").map(|arch| arch != "wasm32") == Ok(true);
         match self {
             Self::Server => builder
                 .build_client(true)
                 .build_server(true)
-                .build_transport(true),
+                .build_transport(transport),
             Self::Client => builder
                 .build_client(true)
                 .build_server(false)
-                .build_transport(true),
+                .build_transport(transport),
             Self::Wasm => builder
                 .build_client(true)
                 .build_server(false)

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -26,6 +26,11 @@ backon = { version = "1.3", default-features = false, features = [
   "tokio-sleep",
 ] }
 tokio = { version = "1.40", features = ["time"] }
+# The native transport (tonic channel + TLS) comes from dapi-grpc's transport
+# feature; wasm builds use tonic-web-wasm-client instead and must not pull it.
+dapi-grpc = { path = "../dapi-grpc", features = [
+  "transport",
+], default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.3.0", features = ["futures"] }


### PR DESCRIPTION
## Issue being fixed or feature implemented

`dapi-grpc` unconditionally built tonic with its native channel and TLS transport stack, so consumers that only need generated message types or proof verification also pulled hyper, rustls, ring, and tower into their dependency trees. `drive-proof-verifier` is a concrete synchronous consumer that does not open network connections.

This is the transport-feature prerequisite extracted from #4335. It lets embedders such as Dash Core use Platform proof verification without inheriting a networking implementation they do not use.

## What was done?

- Added an opt-in `transport` feature to `dapi-grpc` for tonic channel, transport, and TLS support.
- Kept `dapi-grpc` defaults transport-free because Cargo features are additive and cannot be target-scoped.
- Made `build.rs` emit tonic transport helpers only when `transport` is enabled and never for `wasm32`.
- Kept native networking available through `rs-dapi-client`'s non-wasm target dependency.
- Made the `server` feature imply `transport`, preserving the DAPI server build.
- Added CI guards for:
  - hyper, rustls, and tower in `drive-proof-verifier`'s native dependency tree;
  - hyper, rustls, tower, and mio in the default `dash-sdk` and `wasm-sdk` wasm32 dependency trees.
- Added `dapi-grpc` to the nightly per-feature package matrix.

Types-only consumers can use:

```toml
dapi-grpc = { default-features = false, features = ["platform", "client"] }
```

## How Has This Been Tested?

Validated after rebasing onto current `v4.2-dev`:

- `cargo fmt --check --all`
- native, wasm32, and explicit types-only `dapi-grpc` checks
- `drive-proof-verifier`, `rs-dapi-client`, and default `dash-sdk` checks
- native and wasm32 dependency leak guards
- feature-tree assertions proving native `dash-sdk` includes transport while wasm32 `dash-sdk` does not

The corrected full #4335 series is rebased and validated separately on top of this prerequisite.

## Breaking Changes

SDK users and in-repository consumers retain native transport through the appropriate native client or server dependency.

External native consumers that depend directly on `dapi-grpc` and call generated `connect()` methods must explicitly enable `features = ["transport"]`. wasm32 consumers can now use the default feature set without pulling an incompatible native transport graph.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional native transport and TLS support for gRPC clients.
  * Server functionality now includes transport capabilities when enabled.
  * WebAssembly builds remain transport-free for lighter, network-independent deployments.

* **Tests**
  * Expanded nightly feature checks to include the gRPC package.
  * Added validation to ensure transport and networking dependencies remain excluded from selected WebAssembly and verifier builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->