### PR TITLE
feat(kotlin-sdk): coinjoin-drain shielded funding binding + typed asset-lock shortfall

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
@@ -100,6 +100,27 @@ sealed class DashSdkError(
             PlatformWallet(message, cause)
 
         /**
+         * `ErrorAssetLockInsufficientFunds` (native code 29). Asset-lock coin
+         * selection came up short on the ONE funds account the caller selected
+         * — asset-lock funding never unions across accounts, so another source
+         * must be named explicitly rather than combined automatically.
+         *
+         * Distinct from [CoreInsufficientFunds] (22), which is the atomic
+         * Core-send selector rather than the asset-lock builder. The shortfall
+         * figures travel in [message] as `available {n} duffs, required {n}
+         * duffs` — the native result is ABI-frozen to code + message, so there
+         * are no structured fields to read.
+         *
+         * Raised by
+         * [shieldedFundFromCoinJoinDrain][org.dashfoundation.dashsdk.wallet.PlatformWalletManager.shieldedFundFromCoinJoinDrain]
+         * when the CoinJoin account has nothing to drain, and by
+         * [shieldedFundFromAssetLock][org.dashfoundation.dashsdk.wallet.PlatformWalletManager.shieldedFundFromAssetLock]
+         * when the funding account cannot cover the requested lock.
+         */
+        class AssetLockInsufficientFunds(message: String, cause: Throwable? = null) :
+            PlatformWallet(message, cause)
+
+        /**
          * `ErrorShieldedNoRecordedAnchor` (native code 19). A shielded spend
          * could not be built against a Platform-recorded anchor because the
          * local commitment tree is mid-block. Nothing was broadcast and the
@@ -470,10 +491,11 @@ sealed class DashSdkError(
             24 -> PlatformWallet.AssetLockAlreadyConsumed(message, cause) // ErrorAssetLockAlreadyConsumed
             25 -> PlatformWallet.AssetLockFundingMismatch(message, cause) // ErrorAssetLockFundingMismatch
             26 -> PlatformWallet.TransactionBroadcastRejected(message, cause) // ErrorTransactionBroadcastRejected
+            29 -> PlatformWallet.AssetLockInsufficientFunds(message, cause) // ErrorAssetLockInsufficientFunds
             // The deferred-token trio sits at the contiguous block 34-36 because
             // 27-33 are claimed elsewhere: 27 ErrorShutdownIncomplete
             // (dashpay/platform#4268, merged), 29 ErrorAssetLockInsufficientFunds
-            // (#4184), 31 ErrorSigningKeyUnavailable (#4183/#4259), 32
+            // (mapped above), 31 ErrorSigningKeyUnavailable (#4183/#4259), 32
             // ErrorTransactionBuild (#4247/#4256), 33 ErrorTransactionSigning
             // (#4256). See packages/rs-platform-wallet-ffi/ERROR_CODE_REGISTRY.md.
             34 -> PlatformWallet.StaleReservationToken(message, cause) // ErrorStaleReservationToken

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/FundingNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/FundingNative.kt
@@ -63,6 +63,26 @@ internal object FundingNative {
     )
 
     /**
+     * Fund the shielded pool by DRAINING the wallet's CoinJoin account into a
+     * single asset lock (bridges
+     * `platform_wallet_manager_shielded_fund_from_asset_lock_coinjoin_drain`).
+     * Sibling of [shieldedFundFromAssetLock] with drain funding: there is no
+     * amount (the lock value is `Σ inputs − L1 fee`, computed Rust-side) and no
+     * surplus output (the single-recipient remainder flow pins it to zero).
+     * [coinJoinAccountIndex] selects the CoinJoin account to drain;
+     * [recipientRaw43] is the 43-byte raw Orchard address; [coreSignerHandle]
+     * is the manager's `MnemonicResolverHandle`. Blocks for the ~30s Halo 2
+     * proof; the note arrives on the next shielded sync.
+     */
+    external fun shieldedFundFromCoinJoinDrain(
+        managerHandle: Long,
+        walletId: ByteArray,
+        coinJoinAccountIndex: Int,
+        recipientRaw43: ByteArray,
+        coreSignerHandle: Long,
+    )
+
+    /**
      * Resume a stuck shielded fund-from-asset-lock by outpoint (bridges
      * `platform_wallet_manager_shielded_resume_fund_from_asset_lock`).
      * [outPointTxid] is the 32-byte raw txid (little-endian wire order).

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
@@ -1481,6 +1481,54 @@ class PlatformWalletManager(
     }
 
     /**
+     * Fund a wallet's shielded (Orchard) pool by DRAINING its CoinJoin account
+     * (`m/9'/coinType'/4'/coinJoinAccountIndex'`) into a single asset lock —
+     * port of Swift's `shieldedFundFromCoinJoinDrain`.
+     *
+     * Sibling of [shieldedFundFromAssetLock] with drain funding, which is what
+     * makes this the CoinJoin → Shielded migration path: every final mixed-coin
+     * UTXO is consumed and the lock value is `Σ inputs − L1 fee`, computed
+     * Rust-side, so the mixed coins never hop through a transparent BIP44
+     * address on the way in. Hence no amount parameter, and no surplus output
+     * (the single-recipient remainder flow pins the consensus surplus to zero).
+     *
+     * The recipient receives `lockValue − poolFee` credits. The Rust preflight
+     * rejects a drain whose balance could not clear the Type 18 pool fee, so an
+     * unrecoverable dust lock is never broadcast; a drain of an empty account
+     * fails with the typed asset-lock shortfall
+     * ([org.dashfoundation.dashsdk.errors.DashSdkError.PlatformWallet.AssetLockInsufficientFunds]).
+     * A stuck lock resumes via [shieldedResumeFundFromAssetLock] exactly like a
+     * BIP44-funded one.
+     *
+     * Blocks for the ~30s Halo 2 proof; the shielded note itself arrives on the
+     * next shielded sync pass, so nothing is returned.
+     *
+     * @param walletId the 32-byte wallet id.
+     * @param recipientRaw43 the 43-byte raw Orchard payment address
+     *   (11-byte diversifier + 32-byte pk_d).
+     * @param coinJoinAccountIndex the CoinJoin account whose whole balance
+     *   funds the asset lock (account 0 for every current wallet).
+     */
+    suspend fun shieldedFundFromCoinJoinDrain(
+        walletId: ByteArray,
+        recipientRaw43: ByteArray,
+        coinJoinAccountIndex: Int = 0,
+    ): Unit = teardownGate.op {
+        require(coinJoinAccountIndex >= 0) {
+            "coinJoinAccountIndex must be non-negative, got $coinJoinAccountIndex"
+        }
+        mapNativeErrors {
+            FundingNative.shieldedFundFromCoinJoinDrain(
+                managerHandle,
+                walletId,
+                coinJoinAccountIndex,
+                recipientRaw43,
+                mnemonicResolverHandle,
+            )
+        }
+    }
+
+    /**
      * Shield from Platform balance (Type 15) — port of Swift's
      * `shieldedShield`. Spends [amount] credits from the wallet's
      * [paymentAccount] Platform-Payment addresses (auto-selected in

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
@@ -100,6 +100,31 @@ class DashSdkErrorTest {
             DashSdkError.fromNative(DashSDKException(offset + 22, "inputs reserved"))
         assertTrue(coreInsufficientFunds is DashSdkError.PlatformWallet.CoreInsufficientFunds)
 
+        // The asset-lock coin-selection shortfall (29) must reach callers as its
+        // own type rather than Generic, and must stay DISTINCT from the atomic
+        // Core-send shortfall (22) — asset-lock funding never unions across
+        // accounts, so hosts message the two differently. Its available/required
+        // duffs ride the message, which must survive verbatim.
+        val assetLockShort = DashSdkError.fromNative(
+            DashSDKException(
+                offset + 29,
+                "asset lock coin selection is short: available 18000000 duffs, " +
+                    "required 100000000 duffs",
+            ),
+        )
+        assertTrue(
+            "code 29 must not fall through to Generic",
+            assetLockShort is DashSdkError.PlatformWallet.AssetLockInsufficientFunds,
+        )
+        assertFalse(
+            "the asset-lock shortfall must not be conflated with the Core-send one",
+            assetLockShort is DashSdkError.PlatformWallet.CoreInsufficientFunds,
+        )
+        assertTrue(
+            "shortfall amounts must survive in the message",
+            assetLockShort.message!!.contains("available 18000000 duffs"),
+        )
+
         val recoveryCodes = mapOf(
             23 to DashSdkError.PlatformWallet.AssetLockNotTracked::class,
             24 to DashSdkError.PlatformWallet.AssetLockAlreadyConsumed::class,

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -216,6 +216,21 @@ pub enum PlatformWalletFFIResultCode {
     /// join instead of erroring. Swift mirror:
     /// `PlatformWalletResultCode.errorShutdownIncomplete`.
     ErrorShutdownIncomplete = 27,
+    /// Asset-lock coin selection came up short over the *permitted* funding
+    /// set (dashpay/platform#4073). Carries the structured
+    /// `available`/`required` duff amounts in the message string — the
+    /// by-value `PlatformWalletFFIResult` is ABI-frozen (code + message only),
+    /// so the figures ride the typed `Display` rendering or not at all.
+    ///
+    /// Distinct from [`Self::ErrorCoreInsufficientFunds`] (22), which is the
+    /// atomic Core-send selector rather than the asset-lock builder. Asset-lock
+    /// funding never unions across accounts, so this names a shortfall on the
+    /// ONE account the caller selected; a host offering another source must
+    /// name it explicitly.
+    ///
+    /// Reached by the CoinJoin → shielded migration when the mixed account
+    /// cannot cover the lock, which is why the Android binding needs it typed.
+    ErrorAssetLockInsufficientFunds = 29,
     /// A state transition could not be signed because the signer has no
     /// usable private key for the requested public key — the stored blob is
     /// missing, stranded, or written under a different Keystore/Keychain
@@ -248,7 +263,10 @@ pub enum PlatformWalletFFIResultCode {
     //
     //   27  ErrorShutdownIncomplete         MERGED on v4.2-dev (dashpay/platform#4268)
     //   28  (free — vacated by this PR)
-    //   29  ErrorAssetLockInsufficientFunds dashpay/platform#4184
+    //   29  ErrorAssetLockInsufficientFunds ALLOCATED above. Claimed by
+    //       dashpay/platform#4184, which was closed unmerged along with its
+    //       successor #4316; this PR salvages the code at its reserved number
+    //       so the ABI matches what every host mirror already documents.
     //   30  (free — vacated by this PR)
     //   31  ErrorSigningKeyUnavailable      dashpay/platform#4183, #4259
     //   32  ErrorTransactionBuild           dashpay/platform#4247, #4256
@@ -604,6 +622,16 @@ impl From<PlatformWalletError> for PlatformWalletFFIResult {
             }
             PlatformWalletError::AssetLockFundingMismatch { .. } => {
                 PlatformWalletFFIResultCode::ErrorAssetLockFundingMismatch
+            }
+            // The asset-lock coin-selection shortfall (dashpay/platform#4073).
+            // Without this arm it flattens to `ErrorUnknown` (99), hiding a
+            // typed shortfall behind the catch-all and forcing hosts to
+            // string-match the Display text. The structured
+            // `available`/`required` duff amounts still travel in the message
+            // (there are no out-params for them), but the code now lets a host
+            // branch on the shortfall without parsing text.
+            PlatformWalletError::AssetLockInsufficientFunds { .. } => {
+                PlatformWalletFFIResultCode::ErrorAssetLockInsufficientFunds
             }
             // A quiesce/drain barrier that did not complete within budget
             // (clear/reset paths). The host must fail closed: keep its
@@ -1074,6 +1102,59 @@ mod tests {
             let result: PlatformWalletFFIResult = error.into();
             assert_eq!(result.code, expected);
         }
+    }
+
+    /// The asset-lock coin-selection shortfall must cross the FFI boundary as
+    /// the dedicated `ErrorAssetLockInsufficientFunds` (29) code — NOT
+    /// `ErrorUnknown` (99) as it did before this arm existed
+    /// (dashpay/platform#4073) — and its structured `available`/`required`
+    /// duffs must survive verbatim in the message so hosts can parse the
+    /// amounts.
+    #[test]
+    fn asset_lock_insufficient_funds_maps_to_dedicated_code() {
+        let err = PlatformWalletError::AssetLockInsufficientFunds {
+            available: 18_000_000,
+            required: 100_000_000,
+        };
+        let rendered = err.to_string();
+        // Guard the exact text hosts (dash-wallet) substring-match on.
+        assert!(
+            rendered.contains("asset lock coin selection is short"),
+            "shortfall Display text changed — coordinate dash-wallet's matcher \
+             (rendered: {rendered})"
+        );
+        let result: PlatformWalletFFIResult = err.into();
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorAssetLockInsufficientFunds,
+            "must not flatten to ErrorUnknown(99) (rendered: {rendered})"
+        );
+        assert_ne!(
+            result.code as i32,
+            PlatformWalletFFIResultCode::ErrorUnknown as i32
+        );
+        assert!(!result.message.is_null());
+        let msg = unsafe { std::ffi::CStr::from_ptr(result.message) }
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            msg, rendered,
+            "structured available/required duffs must survive the FFI boundary verbatim"
+        );
+    }
+
+    /// The numeric value of `ErrorAssetLockInsufficientFunds` is ABI, mirrored
+    /// by hand in the Swift and Kotlin host enums. Pin it so a future
+    /// renumbering of the surrounding block cannot silently re-point a host's
+    /// shortfall branch at some other error.
+    #[test]
+    fn asset_lock_insufficient_funds_code_is_pinned_at_29() {
+        assert_eq!(
+            PlatformWalletFFIResultCode::ErrorAssetLockInsufficientFunds as i32,
+            29,
+            "code 29 is reserved for the asset-lock shortfall in the FFI \
+             error-code registry; hosts mirror the number, not the name"
+        );
     }
 
     /// `WalletAlreadyExists` maps to the dedicated

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -252,6 +252,36 @@ pub enum PlatformWalletError {
         actual_identity_index: u32,
     },
 
+    /// Asset-lock coin selection came up short, so a host (and ultimately the
+    /// wallet UI) can render a precise shortfall instead of a stringly-typed
+    /// "Insufficient funds" message (dashpay/platform#4073).
+    ///
+    /// The `available` figure reflects the single funds account the caller
+    /// selected — the unmixed BIP44 account by default, or an explicit account
+    /// such as CoinJoin. A shortfall here means that *one* account is short:
+    /// asset-lock funding never unions across accounts, so a different source
+    /// must be named explicitly rather than combined automatically.
+    ///
+    /// Distinct from [`CoreInsufficientFunds`] / [`CorePooledInsufficientFunds`],
+    /// which belong to the atomic Core-send selector rather than the asset-lock
+    /// builder, and which carry `Option` amounts because a pooled send may not
+    /// know them. The asset-lock builder always has concrete figures: the
+    /// key-wallet shortfall errors carry their own, and the empty-candidate-set
+    /// case is reported as `available: 0` against the requested target.
+    ///
+    /// On a *drain* build (whole-account funding, e.g. the CoinJoin → shielded
+    /// migration) the requested target is the zero credit-output placeholder
+    /// that key-wallet rewrites to `Σ inputs − fee`, so an empty account
+    /// surfaces here as `available: 0, required: 0` — the "this account has
+    /// nothing to drain" signal. The real floor for a drain is the Type 18 pool
+    /// fee, enforced downstream against the built payload once the lock value
+    /// is known.
+    #[error(
+        "asset lock coin selection is short: available {available} duffs, \
+         required {required} duffs"
+    )]
+    AssetLockInsufficientFunds { available: u64, required: u64 },
+
     #[error("SDK error: {0}")]
     Sdk(#[from] dash_sdk::Error),
 

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -13,9 +13,11 @@ use key_wallet::bip32::DerivationPath;
 use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 use key_wallet::signer::ExtendedPubKeySigner;
 use key_wallet::wallet::managed_wallet_info::asset_lock_builder::{
-    AssetLockFundingAccount, AssetLockFundingType, CreditOutputFunding,
+    AssetLockError, AssetLockFundingAccount, AssetLockFundingType, CreditOutputFunding,
 };
+use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionError;
 use key_wallet::wallet::managed_wallet_info::managed_account_operations::ManagedAccountOperations;
+use key_wallet::wallet::managed_wallet_info::transaction_builder::BuilderError;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::wallet::Wallet;
 
@@ -188,12 +190,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 signer,
             )
             .await
-            .map_err(|e| {
-                PlatformWalletError::AssetLockTransaction(format!(
-                    "Asset lock builder failed: {}",
-                    e
-                ))
-            })?;
+            .map_err(|e| map_builder_error(e, amount_duffs))?;
 
         // 4. Pull the (pubkey, path) for our single credit output.
         //
@@ -964,6 +961,58 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     }
 }
 
+/// Map a key-wallet [`AssetLockError`] to a [`PlatformWalletError`], promoting
+/// every coin-selection shortfall shape to the typed
+/// [`PlatformWalletError::AssetLockInsufficientFunds`] so callers get one
+/// structured shortfall contract (dashpay/platform#4073) instead of a string
+/// they must pattern-match:
+///
+///   - `BuilderError::InsufficientFunds` / `SelectionError::InsufficientFunds`
+///     carry their own exact `available`/`required` duff amounts — preserved
+///     verbatim.
+///   - `SelectionError::NoUtxosAvailable` — the zero-spendable-candidate case,
+///     the MOST extreme shortfall — carries no amounts, so it would otherwise
+///     fall through to the generic string form while *partial* shortfalls
+///     stayed typed. It maps to `available: 0` against the caller's
+///     `requested` target, keeping the empty candidate set on the same
+///     structured path.
+///
+/// `requested` is the caller's target in duffs. On a drain build it is the
+/// zero credit-output placeholder (key-wallet rewrites the value to
+/// `Σ inputs − fee`), so an empty account reports `available: 0, required: 0`
+/// — "nothing to drain". A drain's real floor is the pool fee, enforced
+/// downstream by `broadcast_funded_asset_lock_with_funding` against the built
+/// payload.
+///
+/// Every other builder error keeps the pre-existing generic
+/// `AssetLockTransaction` string form.
+fn map_builder_error(e: AssetLockError, requested: u64) -> PlatformWalletError {
+    match e {
+        AssetLockError::Builder(
+            BuilderError::InsufficientFunds {
+                available,
+                required,
+            }
+            | BuilderError::CoinSelection(SelectionError::InsufficientFunds {
+                available,
+                required,
+            }),
+        ) => PlatformWalletError::AssetLockInsufficientFunds {
+            available,
+            required,
+        },
+        AssetLockError::Builder(BuilderError::CoinSelection(SelectionError::NoUtxosAvailable)) => {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available: 0,
+                required: requested,
+            }
+        }
+        other => {
+            PlatformWalletError::AssetLockTransaction(format!("Asset lock builder failed: {other}"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
@@ -991,6 +1040,68 @@ mod tests {
     use crate::wallet::platform_wallet::PlatformWalletInfo;
     use crate::wallet::platform_wallet::WalletId;
     use crate::{AssetLockFundingType, PlatformWalletError};
+
+    /// The zero-spendable-candidate selection error must surface the SAME
+    /// typed shortfall as a partial shortfall (not the generic string form),
+    /// so hosts stay on one structured path; and a partial shortfall must
+    /// still carry its own exact amounts (dashpay/platform#4073).
+    #[test]
+    fn coin_selection_shortfalls_map_to_typed_insufficient_funds() {
+        use super::{map_builder_error, AssetLockError, BuilderError, SelectionError};
+
+        // Zero spendable candidates -> typed, available: 0, required = requested.
+        match map_builder_error(
+            AssetLockError::Builder(BuilderError::CoinSelection(
+                SelectionError::NoUtxosAvailable,
+            )),
+            12_345,
+        ) {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required,
+            } => {
+                assert_eq!(available, 0, "empty candidate set means nothing available");
+                assert_eq!(
+                    required, 12_345,
+                    "requested target threaded through as required"
+                );
+            }
+            other => panic!("expected typed AssetLockInsufficientFunds, got {other:?}"),
+        }
+
+        // A partial shortfall keeps its own exact amounts; the requested arg is
+        // NOT substituted for the builder's carried values.
+        match map_builder_error(
+            AssetLockError::Builder(BuilderError::CoinSelection(
+                SelectionError::InsufficientFunds {
+                    available: 100,
+                    required: 500,
+                },
+            )),
+            999,
+        ) {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required,
+            } => {
+                assert_eq!(available, 100);
+                assert_eq!(required, 500, "carried amounts win over the requested arg");
+            }
+            other => panic!("expected typed AssetLockInsufficientFunds, got {other:?}"),
+        }
+
+        // A non-shortfall builder error keeps the pre-existing generic string
+        // form — the typed promotion must not swallow unrelated failures.
+        match map_builder_error(AssetLockError::WatchOnlyWallet, 42) {
+            PlatformWalletError::AssetLockTransaction(msg) => {
+                assert!(
+                    msg.starts_with("Asset lock builder failed: "),
+                    "generic form preserved, got {msg}"
+                );
+            }
+            other => panic!("expected generic AssetLockTransaction, got {other:?}"),
+        }
+    }
 
     /// Persistence stub that records every stored changeset so tests can
     /// assert what the asset-lock flow queued. `fail_flush` simulates a
@@ -1369,8 +1480,14 @@ mod tests {
                 &signer,
             )
             .await;
+        // The reserved UTXO leaves zero spendable candidates, so this is the
+        // typed selection shortfall — a stronger assertion than the old generic
+        // build-error match, which any unrelated failure would also satisfy.
         assert!(
-            matches!(rebuild, Err(PlatformWalletError::AssetLockTransaction(_))),
+            matches!(
+                rebuild,
+                Err(PlatformWalletError::AssetLockInsufficientFunds { available: 0, .. })
+            ),
             "rebuild must fail at input selection while the reservation is \
              kept, got {rebuild:?}"
         );
@@ -1475,8 +1592,12 @@ mod tests {
                 &signer,
             )
             .await;
+        // As above: zero spendable candidates is the typed selection shortfall.
         assert!(
-            matches!(rebuild, Err(PlatformWalletError::AssetLockTransaction(_))),
+            matches!(
+                rebuild,
+                Err(PlatformWalletError::AssetLockInsufficientFunds { available: 0, .. })
+            ),
             "rebuild must fail at input selection while the reservation is \
              kept for the advanced row, got {rebuild:?}"
         );

--- a/packages/rs-unified-sdk-jni/src/funding.rs
+++ b/packages/rs-unified-sdk-jni/src/funding.rs
@@ -371,6 +371,66 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
     })
 }
 
+/// Fund the shielded pool by DRAINING the wallet's CoinJoin account
+/// (`m/9'/coinType'/4'/accountIndex'`) into a single asset lock — bridges
+/// `platform_wallet_manager_shielded_fund_from_asset_lock_coinjoin_drain`.
+///
+/// Mirrors Swift's `PlatformWalletManager.shieldedFundFromCoinJoinDrain`.
+/// Sibling of [`Java_..._shieldedFundFromAssetLock`] with drain funding, so
+/// it differs in exactly two ways:
+///
+/// 1. **No amount** — every final mixed-coin UTXO is consumed and the lock
+///    value is `Σ inputs − L1 fee`, computed Rust-side. The mixed coins never
+///    hop through a transparent BIP44 address, which is what makes this the
+///    CoinJoin → Shielded migration path rather than a normal shield.
+/// 2. **No surplus output** — the single-recipient remainder flow pins the
+///    consensus surplus to zero, so the parameter is omitted rather than
+///    plumbed as null.
+///
+/// `coinJoinAccountIndex` selects the CoinJoin account to drain (0 for every
+/// current wallet); `recipientRaw43` is the 43-byte raw Orchard address;
+/// `coreSignerHandle` is the manager's `MnemonicResolverHandle`. The Rust
+/// preflight rejects a drain whose balance could not clear the Type 18 pool
+/// fee, so an unrecoverable dust lock is never broadcast, and a stuck lock
+/// resumes through the same `shieldedResumeFundFromAssetLock` entry point as a
+/// BIP44-funded one. The ~30s Halo 2 proof runs inside the call; nothing is
+/// returned on success.
+#[no_mangle]
+pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shieldedFundFromCoinJoinDrain(
+    mut env: JNIEnv,
+    _class: JClass,
+    manager_handle: jlong,
+    wallet_id: JByteArray,
+    coin_join_account_index: jint,
+    recipient_raw43: JByteArray,
+    core_signer_handle: jlong,
+) {
+    guard(&mut env, (), |env| {
+        // Reject a negative index at the boundary — it would otherwise
+        // bit-cast to a huge u32 on the FFI call.
+        if coin_join_account_index < 0 {
+            throw_sdk_exception(env, 1, "coinJoinAccountIndex must be non-negative");
+            return;
+        }
+        let Some(wid) = read_id32(env, &wallet_id, "walletId") else {
+            return;
+        };
+        let Some(recipient) = read_recipient43(env, &recipient_raw43) else {
+            return;
+        };
+        let result = unsafe {
+            platform_wallet_ffi::platform_wallet_manager_shielded_fund_from_asset_lock_coinjoin_drain(
+                manager_handle as Handle,
+                wid.as_ptr(),
+                coin_join_account_index as u32,
+                recipient.as_ptr(),
+                core_signer_handle as *mut MnemonicResolverHandle,
+            )
+        };
+        let _ = take_pwffi_error(env, result);
+    })
+}
+
 /// Resume a shielded fund-from-asset-lock from an already-tracked lock by
 /// outpoint — bridges
 /// `platform_wallet_manager_shielded_resume_fund_from_asset_lock`. Sibling


### PR DESCRIPTION
The two Android-facing pieces #4327 left out. Both are small and independent of each other; they meet at one user action.

## 1. Kotlin/JNI binding for CoinJoin-drain shielded funding

#4327 landed the FFI export `platform_wallet_manager_shielded_fund_from_asset_lock_coinjoin_drain` and a Swift wrapper, but no Kotlin/JNI — so Android currently cannot call CoinJoin-funded shielding at all.

This adds the JNI export in `rs-unified-sdk-jni` and the Kotlin surface (`FundingNative.shieldedFundFromCoinJoinDrain`, `PlatformWalletManager.shieldedFundFromCoinJoinDrain`), shaped like the existing `shieldedFundFromAssetLock` binding and following the Swift wrapper's contract:

- **no amount** — every final mixed-coin UTXO is consumed and the lock value is `Σ inputs − L1 fee`, computed Rust-side, so the mixed coins never hop through a transparent BIP44 address;
- **no surplus output** — the single-recipient remainder flow pins the consensus surplus to zero, so the parameter is omitted rather than plumbed as null.

The negative-index guard matches the sibling binding's boundary check (a negative `jint` would otherwise bit-cast to a huge `u32`).

The mixed-funds migration in the Android wallet depends on this binding — it is the CoinJoin → Shielded path.

## 2. Typed asset-lock shortfall at its reserved code 29

The FFI error registry has reserved 29 for `ErrorAssetLockInsufficientFunds` since #4184, and the Swift and Kotlin mirrors already document the number — but the code was never allocated, because #4184 and its successor #4316 were both closed unmerged. That also left the producing `PlatformWalletError::AssetLockInsufficientFunds` variant absent, so there was nothing to map from.

This salvages the minimum needed to make the reserved code real (#4073):

- the `AssetLockInsufficientFunds { available, required }` variant;
- a builder-error mapper promoting every key-wallet coin-selection shortfall to it. `InsufficientFunds` shapes keep their own exact amounts; `NoUtxosAvailable` — the most extreme shortfall — previously fell through to the generic string form while *partial* shortfalls stayed typed, and now maps to `available: 0` against the requested target. Every other builder error keeps its existing generic string;
- the FFI variant at 29, its `From` arm, and tests pinning both the mapping and the number.

Without the `From` arm a shortfall flattens to `ErrorUnknown` (99), forcing hosts to substring-match the Display text. The amounts still ride the message — `PlatformWalletFFIResult` is ABI-frozen to code + message — but hosts can now branch on the code.

Two existing asset-lock tests asserted the old generic error for a "fails at input selection" rebuild; they now assert the typed shortfall with `available: 0`, which is a stronger statement of the same intent.

### Why these two are in one PR

Draining an empty CoinJoin account *is* a coin-selection shortfall. The binding is how Android runs the migration; code 29 is how it explains the most likely failure without parsing English.

## Testing

- `cargo test -p platform-wallet --lib` — 611 passed
- `cargo test -p platform-wallet-ffi` — 263 + 26 + 6 passed
- `cargo clippy -p platform-wallet -p platform-wallet-ffi -p rs-unified-sdk-jni --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `./gradlew :sdk:assembleDebug :sdk:testDebugUnitTest` — BUILD SUCCESSFUL

The Halo 2 proving path itself is unchanged and untested here; this PR only adds the call surface to it.
