### PR TITLE
feat(platform-wallet): pool BIP44 + BIP32 + DashPay receiving funds on the asset-lock path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "dash-network",
 ]
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1805,12 +1805,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 
 [[package]]
 name = "glob"
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "aes",
  "async-trait",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b056d07c61f8618f05082552bbb88072290d57c1#b056d07c61f8618f05082552bbb88072290d57c1"
+source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "dash-network",
 ]
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1805,12 +1805,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 
 [[package]]
 name = "glob"
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "aes",
  "async-trait",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "dash-network",
 ]
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1805,12 +1805,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 
 [[package]]
 name = "glob"
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "aes",
  "async-trait",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/bfoss765/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1a1263a27fa96f7dbf9b283f6fc14101149ab5fd#1a1263a27fa96f7dbf9b283f6fc14101149ab5fd"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "b056d07c61f8618f05082552bbb88072290d57c1" }
+dashcore = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dash-network-seeds = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dash-spv = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+key-wallet = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+key-wallet-ffi = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+key-wallet-manager = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dash-network = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dashcore-rpc = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dash-network-seeds = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dash-spv = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-key-wallet = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-key-wallet-ffi = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-key-wallet-manager = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dash-network = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dashcore-rpc = { git = "https://github.com/bfoss765/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "1a1263a27fa96f7dbf9b283f6fc14101149ab5fd" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
 
 tokio-metrics = "0.5"
 

--- a/packages/rs-platform-wallet-ffi/src/asset_lock/build.rs
+++ b/packages/rs-platform-wallet-ffi/src/asset_lock/build.rs
@@ -20,6 +20,14 @@ use std::os::raw::c_char;
 
 /// Build an asset lock transaction via an external mnemonic resolver.
 ///
+/// Funding is POOLED across `platform_wallet::ASSET_LOCK_FUNDING_SOURCES`:
+/// coin selection draws from the union of the BIP44 and BIP32 accounts at
+/// `account_index` plus every DashPay contact-receiving account, and change
+/// returns to BIP44. A lock therefore no longer needs its whole amount sitting
+/// in one account, and the caller no longer has to sweep accounts together
+/// first. `account_index` addresses the standard families only; DashPay
+/// accounts span their own indices and are pooled in regardless.
+///
 /// On success:
 /// - `out_tx_bytes`/`out_tx_len`: serialized signed transaction
 /// - `out_derivation_path`: NUL-terminated C string with the

--- a/packages/rs-platform-wallet-ffi/src/asset_lock/manager.rs
+++ b/packages/rs-platform-wallet-ffi/src/asset_lock/manager.rs
@@ -12,7 +12,9 @@ pub struct TrackedAssetLockFFI {
     pub txid: [u8; 32],
     /// Outpoint vout.
     pub vout: u32,
-    /// BIP44 account index.
+    /// Family-independent source index of the pooled funding (BIP44 and
+    /// BIP32 at this index plus DashPay receiving accounts). Not a
+    /// BIP44-only selector.
     pub account_index: u32,
     /// Funding type (0=IdentityRegistration, 1=IdentityTopUp, 2=IdentityTopUpNotBound,
     /// 3=IdentityInvitation, 4=AssetLockAddressTopUp, 5=AssetLockShieldedAddressTopUp).

--- a/packages/rs-platform-wallet-ffi/src/asset_lock_persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/asset_lock_persistence.rs
@@ -41,7 +41,9 @@ pub struct AssetLockEntryFFI {
     /// for the callback window.
     pub transaction_bytes: *const u8,
     pub transaction_bytes_len: usize,
-    /// BIP44 account index that funded this asset lock.
+    /// Family-independent source index of the pooled funding (BIP44 and
+    /// BIP32 at this index plus DashPay receiving accounts; change
+    /// returns to BIP44). Not a BIP44-only selector.
     pub account_index: u32,
     /// Discriminant of [`key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingType`]:
     /// 0 = IdentityRegistration, 1 = IdentityTopUp, 2 = IdentityTopUpNotBound,

--- a/packages/rs-platform-wallet-ffi/src/identity_registration_funded_with_signer.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_registration_funded_with_signer.rs
@@ -43,12 +43,13 @@ fn existing_asset_lock_funding(
 
 /// Register a new asset-lock-funded identity using an external signer.
 ///
-/// `account_index` selects which BIP44 *standard* account (by BIP44
-/// account index) the asset-lock funding UTXOs are drawn from. Only
-/// BIP44 standard accounts are supported today; the Swift UI is
-/// expected to filter the funding picker accordingly (CoinJoin / BIP32
-/// funding for new-identity registration is not yet wired through
-/// `create_funded_asset_lock_proof`).
+/// `account_index` addresses the *standard* families: the asset-lock
+/// funding POOLS the BIP44 and BIP32 accounts at that index together
+/// with every DashPay receiving account (change returns to BIP44).
+/// The index does not restrict which DashPay receiving accounts
+/// contribute, so the UI must not present it as an account-scoped
+/// funding or privacy choice. CoinJoin funding remains drain-only and
+/// is not reachable here.
 ///
 /// # Safety
 /// - `signer_handle` must be a valid, non-destroyed `*mut SignerHandle`

--- a/packages/rs-platform-wallet-ffi/src/identity_top_up.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_top_up.rs
@@ -170,9 +170,12 @@ const MIN_TOP_UP_DUFFS: u64 = 50_500;
 /// with [`AssetLockFunding::FromWalletBalance`] — the same L2 orchestrator
 /// (funding resolution, IS→CL fallback, asset-lock cleanup) that
 /// [`platform_wallet_register_identity_with_funding_signer`] drives for
-/// registration. `account_index` selects which BIP44 *standard* account
-/// the asset-lock UTXOs are drawn from (only BIP44 standard accounts are
-/// supported today, matching registration).
+/// registration. `account_index` addresses the *standard* families: the
+/// asset lock POOLS the BIP44 and BIP32 accounts at that index together
+/// with every DashPay receiving account (change returns to BIP44). The
+/// index does not restrict which DashPay receiving accounts contribute —
+/// callers must not present this as an account-scoped funding or privacy
+/// choice (matching registration).
 ///
 /// Unlike registration this takes NO identity-key signer: the
 /// `IdentityTopUp` state-transition is signed entirely by the asset lock's

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -5657,9 +5657,12 @@ impl UnresolvedRestoreStats {
 }
 
 /// Project a slice of [`UnresolvedAssetLockTxRecordFFI`] rows onto the
-/// in-memory `transactions()` maps of the matching
-/// `standard_bip44_accounts[account_index]` slots on the rebuilt
-/// `ManagedWalletInfo`.
+/// in-memory `transactions()` maps of the rebuilt `ManagedWalletInfo`,
+/// routing each record to the first present family the proof lookup
+/// searches: `standard_bip44_accounts[account_index]`, then
+/// `standard_bip32_accounts[account_index]`, then
+/// `coinjoin_accounts[account_index]`, then any DashPay receival
+/// account (the lookup scans those by txid, index-independent).
 ///
 /// See the call site in [`build_wallet_start_state`] for the design
 /// rationale on WHY this exists at all (selective bulk-restore for

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -5735,22 +5735,43 @@ fn restore_unresolved_asset_lock_tx_records(
             _ => TransactionContext::Mempool,
         };
 
-        // Asset-lock txs are funded from a BIP44 account; that's
-        // the only account map the asset-lock recovery flow
-        // consults (`recover_asset_lock_blocking` reads
-        // `info.core_wallet.accounts.standard_bip44_accounts.get(
-        // &account_index)...transactions().get(&out_point.txid)`),
-        // so restoration goes through the same map. Records for
-        // other variants would never be reached by that lookup.
-        let Some(account) = wallet_info
-            .accounts
+        // A pooled asset lock can be funded ENTIRELY from a BIP32
+        // account or a DashPay receiving account — the builder
+        // deliberately skips absent source families — so
+        // `standard_bip44_accounts[account_index]` may not exist
+        // for a perfectly valid record. The recovery lookup
+        // (`funding_tx_record` in sync::proof) searches BIP44 and
+        // BIP32 by this index, CoinJoin by index, and DashPay
+        // receiving accounts by txid regardless of index; restore
+        // the synthetic record into the FIRST present family that
+        // lookup searches instead of dropping it — a dropped
+        // record leaves an already-broadcast lock stuck at
+        // `Broadcast` after restart, unrecoverable by any later
+        // promotion path.
+        let accounts = &mut wallet_info.accounts;
+        let account = if accounts
             .standard_bip44_accounts
-            .get_mut(&rec.account_index)
-        else {
+            .contains_key(&rec.account_index)
+        {
+            accounts.standard_bip44_accounts.get_mut(&rec.account_index)
+        } else if accounts
+            .standard_bip32_accounts
+            .contains_key(&rec.account_index)
+        {
+            accounts.standard_bip32_accounts.get_mut(&rec.account_index)
+        } else if accounts.coinjoin_accounts.contains_key(&rec.account_index) {
+            accounts.coinjoin_accounts.get_mut(&rec.account_index)
+        } else {
+            // Any receival account works: the proof lookup scans
+            // them all by txid, ignoring the tracked source index.
+            accounts.dashpay_receival_accounts.values_mut().next()
+        };
+        let Some(account) = account else {
             stats.dropped_no_account += 1;
             tracing::warn!(
                 account_index = rec.account_index,
-                "load: dropping unresolved-asset-lock tx record — no matching BIP44 account"
+                "load: dropping unresolved-asset-lock tx record — no account in any \
+                 family the proof lookup searches"
             );
             continue;
         };
@@ -6640,6 +6661,123 @@ mod tests {
             .expect("inserting the single account must succeed");
         let wallet = Wallet::new_external_signable(Network::Testnet, [0u8; 32], accounts);
         ManagedWalletInfo::from_wallet(&wallet, 0)
+    }
+
+    /// Same construction as `test_managed_wallet_info_with_bip44` but with a
+    /// single account of the given standard/DashPay `account_type` — the
+    /// pooled-restore tests need wallets whose ONLY account is a non-BIP44
+    /// family, because that's exactly the shape the pooled builder produces
+    /// when it skips absent source families.
+    fn test_managed_wallet_info_with_account(account_type: AccountType) -> ManagedWalletInfo {
+        let mnemonic = Mnemonic::from_phrase(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            Language::English,
+        )
+        .expect("static BIP-39 vector must parse");
+        let seed = mnemonic.to_seed("");
+        let master = ExtendedPrivKey::new_master(Network::Testnet, &seed)
+            .expect("master derivation must succeed");
+        let secp = Secp256k1::new();
+        let xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let account = Account::from_xpub(None, account_type, xpub, Network::Testnet)
+            .expect("Account::from_xpub on a valid xpub must succeed");
+        let mut accounts = key_wallet::AccountCollection::new();
+        accounts
+            .insert(account)
+            .expect("inserting the single account must succeed");
+        let wallet = Wallet::new_external_signable(Network::Testnet, [0u8; 32], accounts);
+        ManagedWalletInfo::from_wallet(&wallet, 0)
+    }
+
+    /// A lock funded EXCLUSIVELY from a BIP32 account (the pooled builder
+    /// skips absent families, so no BIP44 account exists at the index) must
+    /// restore into `standard_bip32_accounts` — the pre-fix bridge only
+    /// consulted BIP44 and dropped the record, leaving an already-broadcast
+    /// lock unrecoverable after restart.
+    #[test]
+    fn restore_routes_to_bip32_when_indexed_bip44_absent() {
+        let mut wallet_info = test_managed_wallet_info_with_account(AccountType::Standard {
+            index: 7,
+            standard_account_type: StandardAccountType::BIP32Account,
+        });
+        let tx = synthetic_minimal_tx();
+        let txid = tx.txid();
+        let mut tx_buf: Vec<u8> = serialize(&tx);
+
+        let rec = UnresolvedAssetLockTxRecordFFI {
+            account_index: 7,
+            tx_bytes: tx_buf.as_mut_ptr(),
+            tx_bytes_len: tx_buf.len(),
+            context_raw: 2,
+            block_height: 1475917,
+            block_hash: [0x42u8; 32],
+            block_timestamp: 1700000000,
+            first_seen: 1699999000,
+        };
+
+        let stats = restore_unresolved_asset_lock_tx_records(&mut wallet_info, &[rec])
+            .expect("restoration should not error");
+        assert_eq!(
+            stats.restored, 1,
+            "the BIP32-only record must restore, not drop"
+        );
+        assert!(
+            wallet_info
+                .accounts
+                .standard_bip32_accounts
+                .get(&7)
+                .expect("BIP32 account 7 must exist")
+                .transactions()
+                .contains_key(&txid),
+            "the restored record must land in the BIP32 account the proof lookup searches"
+        );
+        drop(tx_buf);
+    }
+
+    /// A lock funded EXCLUSIVELY from a DashPay receiving account (no
+    /// standard account exists at the tracked index at all) must restore
+    /// into a receival account — the proof lookup scans them by txid,
+    /// ignoring the tracked source index, so any receival account makes the
+    /// record findable again after restart.
+    #[test]
+    fn restore_routes_to_dashpay_receival_when_indexed_standard_absent() {
+        let mut wallet_info =
+            test_managed_wallet_info_with_account(AccountType::DashpayReceivingFunds {
+                index: 2,
+                user_identity_id: [0x11u8; 32],
+                friend_identity_id: [0x22u8; 32],
+            });
+        let tx = synthetic_minimal_tx();
+        let txid = tx.txid();
+        let mut tx_buf: Vec<u8> = serialize(&tx);
+
+        let rec = UnresolvedAssetLockTxRecordFFI {
+            // Tracked source index that matches NO standard account.
+            account_index: 3,
+            tx_bytes: tx_buf.as_mut_ptr(),
+            tx_bytes_len: tx_buf.len(),
+            context_raw: 2,
+            block_height: 1475917,
+            block_hash: [0x42u8; 32],
+            block_timestamp: 1700000000,
+            first_seen: 1699999000,
+        };
+
+        let stats = restore_unresolved_asset_lock_tx_records(&mut wallet_info, &[rec])
+            .expect("restoration should not error");
+        assert_eq!(
+            stats.restored, 1,
+            "the DashPay-only record must restore, not drop"
+        );
+        assert!(
+            wallet_info
+                .accounts
+                .dashpay_receival_accounts
+                .values()
+                .any(|account| account.transactions().contains_key(&txid)),
+            "the restored record must land in a receival account (searched by txid)"
+        );
+        drop(tx_buf);
     }
 
     /// Same reproducible testnet xpub as `test_managed_wallet_info_with_bip44`,

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
@@ -34,10 +34,12 @@ use crate::{unwrap_option_or_return, unwrap_result_or_return};
 /// → consume), with the asset-lock signature produced by an external
 /// `MnemonicResolverHandle`.
 ///
-/// `account_index` selects the BIP44 *standard* Core account whose
-/// UTXOs fund the asset lock (only BIP44 standard accounts supported
-/// today). `platform_account_index` selects which platform-payment
-/// account the recipient addresses belong to.
+/// `account_index` addresses the *standard* Core families: the asset
+/// lock POOLS the BIP44 and BIP32 accounts at that index together with
+/// every DashPay receiving account (change returns to BIP44); the index
+/// does not restrict which DashPay receiving accounts contribute.
+/// `platform_account_index` selects which platform-payment account the
+/// recipient addresses belong to.
 ///
 /// # Safety
 /// - `signer_address_handle` must be a valid, non-destroyed

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -1325,7 +1325,10 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_resume_fund_from_asset
 ///
 /// `account` is the shielded BIP44 account whose default address receives
 /// each real note (must be bound via `bind_shielded`). `funding_account_index`
-/// is the Core BIP44 account whose UTXOs fund each per-batch asset lock.
+/// is the standard-family source index each per-batch asset lock funds from —
+/// it POOLS the BIP44 and BIP32 accounts at that index with every DashPay
+/// receiving account (change returns to BIP44) and does not restrict which
+/// DashPay receiving accounts contribute.
 ///
 /// # Safety
 /// - `wallet_id_bytes` must point to 32 readable bytes.

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -896,8 +896,11 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_shield(
 /// by a `MnemonicResolverHandle` — the raw key never crosses the
 /// FFI boundary.
 ///
-/// `account_index` selects the BIP44 Core account whose UTXOs
-/// fund the asset lock. `amount_duffs` is the L1 amount to lock.
+/// `account_index` addresses the standard Core families: the asset
+/// lock POOLS the BIP44 and BIP32 accounts at that index together
+/// with every DashPay receiving account (change returns to BIP44);
+/// the index does not restrict which DashPay receiving accounts
+/// contribute. `amount_duffs` is the L1 amount to lock.
 /// The wallet derives the shielded credit amount internally
 /// (`lock_value − pool_fee`, where `pool_fee = shielded fee +
 /// asset_lock_base_cost`) — callers don't need to know about

--- a/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
@@ -484,10 +484,11 @@ pub struct UnresolvedAssetLockTxRecordFFI {
     /// Family-independent source index the funding tx spent UTXOs
     /// from — the same `account_index` the Rust `TrackedAssetLock`
     /// carries. A pooled lock can be funded from BIP44, BIP32 or
-    /// DashPay receiving accounts, so load-time routing tries the
-    /// standard families at this index first and falls back to a
-    /// receival account (searched by txid, index-independent) —
-    /// see `restore_unresolved_asset_lock_tx_records`.
+    /// DashPay receiving accounts (CoinJoin backs only the drain
+    /// flow), so load-time routing tries BIP44, then BIP32, then
+    /// CoinJoin at this index, and finally falls back to a receival
+    /// account (searched by txid, index-independent) — see
+    /// `restore_unresolved_asset_lock_tx_records`.
     pub account_index: u32,
     /// Consensus-encoded asset-lock transaction body. Same wire
     /// format `dashcore::consensus::encode::serialize` produces, so

--- a/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
@@ -481,11 +481,13 @@ pub struct UtxoRestoreEntryFFI {
 /// not yet observed IS-lock or block confirmation).
 #[repr(C)]
 pub struct UnresolvedAssetLockTxRecordFFI {
-    /// BIP44 account index the funding tx spent UTXOs from — the
-    /// same `account_index` the Rust `TrackedAssetLock` carries.
-    /// Routes the record into the matching
-    /// `standard_bip44_accounts[account_index].transactions_mut()`
-    /// bucket at load time.
+    /// Family-independent source index the funding tx spent UTXOs
+    /// from — the same `account_index` the Rust `TrackedAssetLock`
+    /// carries. A pooled lock can be funded from BIP44, BIP32 or
+    /// DashPay receiving accounts, so load-time routing tries the
+    /// standard families at this index first and falls back to a
+    /// receival account (searched by txid, index-independent) —
+    /// see `restore_unresolved_asset_lock_tx_records`.
     pub account_index: u32,
     /// Consensus-encoded asset-lock transaction body. Same wire
     /// format `dashcore::consensus::encode::serialize` produces, so

--- a/packages/rs-platform-wallet/src/lib.rs
+++ b/packages/rs-platform-wallet/src/lib.rs
@@ -57,7 +57,9 @@ pub use wallet::asset_lock::manager::AssetLockManager;
 pub use wallet::asset_lock::tracked::{AssetLockStatus, TrackedAssetLock};
 pub use wallet::asset_lock::AssetLockFunding;
 pub use wallet::core::WalletBalance;
-pub use wallet::core::{CoreWallet, SignedCoreTransaction, SEND_FUNDING_SOURCES};
+pub use wallet::core::{
+    CoreWallet, SignedCoreTransaction, ASSET_LOCK_FUNDING_SOURCES, SEND_FUNDING_SOURCES,
+};
 pub use wallet::signed_payment_registry::{
     RegisterWrongGeneration, ReservationToken, SignedPaymentError, SignedPaymentRegistry,
 };

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -16,12 +16,14 @@ use key_wallet::wallet::managed_wallet_info::asset_lock_builder::{
     AssetLockFundingAccount, AssetLockFundingType, CreditOutputFunding,
 };
 use key_wallet::wallet::managed_wallet_info::managed_account_operations::ManagedAccountOperations;
+use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::wallet::Wallet;
 
 use crate::changeset::{AccountRegistrationEntry, PlatformWalletChangeSet};
 use crate::error::PlatformWalletError;
 use crate::wallet::platform_wallet::PlatformWalletInfo;
+use crate::ASSET_LOCK_FUNDING_SOURCES;
 
 use super::manager::{AssetLockManager, DEFAULT_FEE_PER_KB};
 use super::tracked::{AssetLockStatus, TrackedAssetLock};
@@ -61,14 +63,19 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     /// `DerivationPath` is what the caller hands back to the same
     /// `signer` when the credit output is later consumed on Platform.
     ///
-    /// Exact-amount BIP44 form — the historical entry point; the
+    /// Exact-amount form — the historical entry point, now **pooled**: it funds
+    /// from [`ASSET_LOCK_FUNDING_SOURCES`] (BIP44 + BIP32 + every DashPay
+    /// contact-receiving account), so the lock no longer needs its whole amount
+    /// sitting in one account and change returns to BIP44. The
     /// funding-parameterized form is
     /// [`Self::build_asset_lock_transaction_with_funding`].
     ///
     /// # Arguments
     ///
     /// * `amount_duffs` — Amount to lock in duffs.
-    /// * `account_index` — BIP44 account index to select UTXOs from.
+    /// * `account_index` — Index addressing the standard (BIP44/BIP32)
+    ///   families; DashPay contact accounts span their own indices and are
+    ///   pooled in regardless.
     /// * `funding_type` — Which account to derive the one-time key from
     ///   (e.g., `IdentityRegistration`, `IdentityTopUp`).
     /// * `identity_index` — Identity index (used by `IdentityTopUp`, ignored by others).
@@ -89,27 +96,42 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
         self.build_asset_lock_transaction_with_funding(
             AssetLockBuildAmount::Exact(amount_duffs),
-            AssetLockFundingAccount::Bip44 { account_index },
+            &ASSET_LOCK_FUNDING_SOURCES,
+            account_index,
             funding_type,
             identity_index,
             signer,
         )
         .await
-        // Historical callers never had the reservation token; the funded
-        // pipeline (`broadcast_funded_asset_lock_with_funding`) threads it.
-        .map(|(tx, path, _token)| (tx, path))
+        // Historical callers never had the reservation token or the funding
+        // account list; the funded pipeline
+        // (`broadcast_funded_asset_lock_with_funding`) threads both.
+        .map(|(tx, path, _token, _accounts)| (tx, path))
     }
 
     /// Funding-parameterized form of [`Self::build_asset_lock_transaction`]:
-    /// `funding_account` picks the account family supplying (and signing)
-    /// the funding UTXOs, and `amount` picks exact-amount vs whole-balance
-    /// drain semantics (see [`AssetLockBuildAmount`]). CoinJoin funding is
-    /// drain-only — the key-wallet builder rejects a non-drain CoinJoin
-    /// build.
+    /// `funding_sources` names the account families to POOL, in order — the
+    /// first supplies the change address — and `amount` picks exact-amount vs
+    /// whole-balance drain semantics (see [`AssetLockBuildAmount`]).
+    /// `source_index` addresses the standard families; DashPay set selectors
+    /// span their own indices.
+    ///
+    /// A single-element list reproduces the old one-account behavior, including
+    /// its strict account-not-found error; a pooled list skips the sources this
+    /// wallet has nothing for. CoinJoin funding is drain-only *and* cannot be
+    /// pooled — the key-wallet builder rejects both a non-drain CoinJoin build
+    /// and a CoinJoin source combined with any other.
+    ///
+    /// Returns the transaction, the credit-output derivation path, the build's
+    /// reservation token, and the accounts that contributed inputs — the
+    /// caller's release path needs every one of them, since a pooled build
+    /// reserves in each contributing account's own set under the one token.
+    #[allow(clippy::type_complexity)]
     pub async fn build_asset_lock_transaction_with_funding<S: ExtendedPubKeySigner>(
         &self,
         amount: AssetLockBuildAmount,
-        funding_account: AssetLockFundingAccount,
+        funding_sources: &[AccountTypePreference],
+        source_index: u32,
         funding_type: AssetLockFundingType,
         identity_index: u32,
         signer: &S,
@@ -118,6 +140,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             Transaction,
             DerivationPath,
             Option<key_wallet::ReservationToken>,
+            Vec<AccountType>,
         ),
         PlatformWalletError,
     > {
@@ -175,13 +198,16 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         };
 
         // 3. Delegate to the key-wallet signer-driven builder with the
-        // caller's funding account + drain semantics (the key-wallet side
-        // enforces that CoinJoin funding is drain-only).
+        // caller's funding sources + drain semantics (the key-wallet side
+        // pools the sources, enforces that CoinJoin funding is drain-only and
+        // unpooled, and reserves the selected inputs in each contributing
+        // account's own set under one owner token).
         let result = info
             .core_wallet
             .build_asset_lock_with_signer(
                 wallet,
-                funding_account,
+                funding_sources,
+                source_index,
                 vec![funding],
                 DEFAULT_FEE_PER_KB,
                 drain,
@@ -218,7 +244,12 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             }
         };
 
-        Ok((result.transaction, path, result.reservation_token))
+        Ok((
+            result.transaction,
+            path,
+            result.reservation_token,
+            result.funding_accounts,
+        ))
     }
 
     /// Peek at the next unused address from a funding account without
@@ -632,7 +663,9 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     /// ## Parameters
     ///
     /// * `amount_duffs` — Amount to lock.
-    /// * `account_index` — BIP44 account index to select UTXOs from.
+    /// * `account_index` — Index addressing the standard (BIP44/BIP32)
+    ///   families of [`ASSET_LOCK_FUNDING_SOURCES`]; DashPay contact accounts
+    ///   span their own indices and are pooled in regardless.
     /// * `funding_type` — Which account to derive the one-time key from.
     /// * `identity_index` — HD identity index (for `IdentityTopUp`, this is
     ///   the registration index identifying which identity is being topped up).
@@ -646,9 +679,10 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         identity_index: u32,
         signer: &S,
     ) -> Result<(dpp::prelude::AssetLockProof, DerivationPath, OutPoint), PlatformWalletError> {
-        self.create_funded_asset_lock_proof_with_funding(
+        self.create_funded_asset_lock_proof_pooled(
             AssetLockBuildAmount::Exact(amount_duffs),
-            AssetLockFundingAccount::Bip44 { account_index },
+            &ASSET_LOCK_FUNDING_SOURCES,
+            account_index,
             funding_type,
             identity_index,
             signer,
@@ -656,9 +690,12 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         .await
     }
 
-    /// Funding-parameterized form of [`Self::create_funded_asset_lock_proof`]
-    /// — same build → broadcast → proof pipeline with the account family and
-    /// amount semantics of [`Self::build_asset_lock_transaction_with_funding`].
+    /// Whole-balance drain form of [`Self::create_funded_asset_lock_proof`]:
+    /// the caller names the ONE account to drain (`AssetLockFundingAccount`),
+    /// which is how the CoinJoin → shielded path funds a lock directly from
+    /// mixed coins. A drain has no change output, so the question a pooled
+    /// source list answers — which account supplies change — does not arise,
+    /// and CoinJoin must not be pooled with transparent sources anyway.
     pub async fn create_funded_asset_lock_proof_with_funding<S: ExtendedPubKeySigner>(
         &self,
         amount: AssetLockBuildAmount,
@@ -667,17 +704,41 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         identity_index: u32,
         signer: &S,
     ) -> Result<(dpp::prelude::AssetLockProof, DerivationPath, OutPoint), PlatformWalletError> {
+        self.create_funded_asset_lock_proof_pooled(
+            amount,
+            &[AccountTypePreference::from(funding_account)],
+            funding_account.account_index(),
+            funding_type,
+            identity_index,
+            signer,
+        )
+        .await
+    }
+
+    /// Source-list form of [`Self::create_funded_asset_lock_proof`] — same
+    /// build → broadcast → proof pipeline with the pooled funding and amount
+    /// semantics of [`Self::build_asset_lock_transaction_with_funding`].
+    async fn create_funded_asset_lock_proof_pooled<S: ExtendedPubKeySigner>(
+        &self,
+        amount: AssetLockBuildAmount,
+        funding_sources: &[AccountTypePreference],
+        source_index: u32,
+        funding_type: AssetLockFundingType,
+        identity_index: u32,
+        signer: &S,
+    ) -> Result<(dpp::prelude::AssetLockProof, DerivationPath, OutPoint), PlatformWalletError> {
         let (path, out_point) = self
             .broadcast_funded_asset_lock_with_funding(
                 amount,
-                funding_account,
+                funding_sources,
+                source_index,
                 funding_type,
                 identity_index,
                 signer,
             )
             .await?;
         let proof = self
-            .wait_for_funded_asset_lock_proof(&out_point, funding_account.account_index())
+            .wait_for_funded_asset_lock_proof(&out_point, source_index)
             .await?;
         Ok((proof, path, out_point))
     }
@@ -700,7 +761,8 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     ) -> Result<(DerivationPath, OutPoint), PlatformWalletError> {
         self.broadcast_funded_asset_lock_with_funding(
             AssetLockBuildAmount::Exact(amount_duffs),
-            AssetLockFundingAccount::Bip44 { account_index },
+            &ASSET_LOCK_FUNDING_SOURCES,
+            account_index,
             funding_type,
             identity_index,
             signer,
@@ -709,10 +771,12 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     }
 
     /// Funding-parameterized form of [`Self::broadcast_funded_asset_lock`].
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn broadcast_funded_asset_lock_with_funding<S: ExtendedPubKeySigner>(
         &self,
         amount: AssetLockBuildAmount,
-        funding_account: AssetLockFundingAccount,
+        funding_sources: &[AccountTypePreference],
+        source_index: u32,
         funding_type: AssetLockFundingType,
         identity_index: u32,
         signer: &S,
@@ -746,11 +810,15 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         };
         let build_persist_guard = self.build_persist_serial.lock().await;
 
-        // 1. Build the asset lock transaction.
-        let (tx, path, reservation_token) = self
+        // 1. Build the asset lock transaction. `funding_accounts` are the
+        //    accounts that actually contributed inputs — a pooled build
+        //    reserves in each of their own sets under the one token, so every
+        //    release below has to reach all of them.
+        let (tx, path, reservation_token, funding_accounts) = self
             .build_asset_lock_transaction_with_funding(
                 amount,
-                funding_account,
+                funding_sources,
+                source_index,
                 funding_type,
                 identity_index,
                 signer,
@@ -785,21 +853,10 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         {
             if locked_amount_duffs < minimum {
                 drop(build_persist_guard);
-                let reserved_account = match funding_account {
-                    AssetLockFundingAccount::Bip44 { account_index } => {
-                        crate::wallet::reservations::ReservedFundingAccount::Standard(
-                            key_wallet::account::account_type::StandardAccountType::BIP44Account,
-                            account_index,
-                        )
-                    }
-                    AssetLockFundingAccount::CoinJoin { account_index } => {
-                        crate::wallet::reservations::ReservedFundingAccount::CoinJoin(account_index)
-                    }
-                };
                 crate::wallet::reservations::release_reservation_after_rejected_broadcast(
                     &self.wallet_manager,
                     &self.wallet_id,
-                    reserved_account,
+                    &funding_accounts,
                     &tx,
                     reservation_token,
                 )
@@ -852,7 +909,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             .track_asset_lock(TrackedAssetLock {
                 out_point,
                 transaction: tx.clone(),
-                account_index: funding_account.account_index(),
+                account_index: source_index,
                 funding_type,
                 identity_index,
                 amount: locked_amount_duffs,
@@ -868,9 +925,9 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         );
 
         // 3. Broadcast. On a definitive pre-send rejection, untrack the
-        //    `Built` row BEFORE releasing the funding reservation (the
-        //    asset-lock builder funds from the BIP44 account at
-        //    `account_index`): while the reservation is held the inputs
+        //    `Built` row BEFORE releasing the funding reservation (held in
+        //    every account of `funding_accounts`, under the one owner token):
+        //    while the reservation is held the inputs
         //    cannot be re-selected by a new build, and once the row is gone
         //    `resume_asset_lock` can no longer re-drive the rejected
         //    transaction — so at no point is the row resumable while its
@@ -889,23 +946,10 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 let removed_built_row = cs_untrack.removed.contains(&out_point);
                 self.queue_asset_lock_changeset(cs_untrack);
                 if removed_built_row {
-                    let reserved_account = match funding_account {
-                        AssetLockFundingAccount::Bip44 {
-                            account_index,
-                        } => crate::wallet::reservations::ReservedFundingAccount::Standard(
-                            key_wallet::account::account_type::StandardAccountType::BIP44Account,
-                            account_index,
-                        ),
-                        AssetLockFundingAccount::CoinJoin {
-                            account_index,
-                        } => crate::wallet::reservations::ReservedFundingAccount::CoinJoin(
-                            account_index,
-                        ),
-                    };
                     crate::wallet::reservations::release_reservation_after_rejected_broadcast(
                         &self.wallet_manager,
                         &self.wallet_id,
-                        reserved_account,
+                        &funding_accounts,
                         &tx,
                         reservation_token,
                     )
@@ -970,6 +1014,7 @@ mod tests {
 
     use dashcore::OutPoint;
     use key_wallet::account::account_type::StandardAccountType;
+    use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
     use tokio::sync::Notify;
 
     use async_trait::async_trait;
@@ -982,7 +1027,8 @@ mod tests {
         ClientStartState, PersistenceError, PlatformWalletChangeSet, PlatformWalletPersistence,
     };
     use crate::test_support::{
-        funded_wallet_manager, AlwaysMaybeSentBroadcaster, AlwaysOkBroadcaster,
+        funded_wallet_manager, funded_wallet_manager_dual_standard,
+        funded_wallet_manager_with_contact, AlwaysMaybeSentBroadcaster, AlwaysOkBroadcaster,
         AlwaysRejectedBroadcaster, WalletSigner,
     };
     use crate::wallet::asset_lock::manager::AssetLockManager;
@@ -1113,9 +1159,8 @@ mod tests {
                     // (Σ inputs − fee < 10_000_000) must fail the floor.
                     minimum_lock_duffs: Some(u64::MAX),
                 },
-                key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingAccount::CoinJoin {
-                    account_index: 0,
-                },
+                &[AccountTypePreference::CoinJoin],
+                0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
@@ -1155,9 +1200,8 @@ mod tests {
                 super::AssetLockBuildAmount::DrainAll {
                     minimum_lock_duffs: Some(1),
                 },
-                key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingAccount::CoinJoin {
-                    account_index: 0,
-                },
+                &[AccountTypePreference::CoinJoin],
+                0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
@@ -1883,5 +1927,167 @@ mod tests {
                 }
             }
         }
+    }
+
+    // -- Pooled asset-lock funding ---------------------------------------
+
+    /// Build an `AssetLockManager` over an already-built wallet manager.
+    fn asset_lock_manager_over<B: TransactionBroadcaster>(
+        wallet_manager: Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
+        wallet_id: WalletId,
+        broadcaster: Arc<B>,
+    ) -> (Arc<AssetLockManager<B>>, Arc<CapturingPersistence>) {
+        let persistence = Arc::new(CapturingPersistence::default());
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let manager = Arc::new(AssetLockManager::new(
+            sdk,
+            wallet_manager,
+            wallet_id,
+            Arc::new(Notify::new()),
+            broadcaster,
+            WalletPersister::new(
+                wallet_id,
+                Arc::clone(&persistence) as Arc<dyn PlatformWalletPersistence>,
+            ),
+        ));
+        (manager, persistence)
+    }
+
+    /// THE POINT OF THIS CHANGE: an asset lock larger than either standard
+    /// family holds is funded from BOTH in one transaction. Before pooling
+    /// this was `CoreInsufficientFunds` unless the caller first swept the
+    /// accounts together and locked out of the sweep — an extra on-chain hop
+    /// and fee.
+    #[tokio::test]
+    async fn pooled_asset_lock_spans_the_standard_families() {
+        let (wallet_manager, wallet_id, _generation, signer) =
+            funded_wallet_manager_dual_standard(&[700_000], &[700_000]).await;
+        let (manager, _persistence) = asset_lock_manager_over(
+            wallet_manager,
+            wallet_id,
+            Arc::new(CountingOkBroadcaster::default()),
+        );
+
+        // 1_000_000 exceeds either family's 700_000, so selection must pool.
+        let (_path, out_point) = manager
+            .broadcast_funded_asset_lock(
+                1_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &signer,
+            )
+            .await
+            .expect("a lock above either family's balance must pool both");
+
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm.get_wallet_and_info(&wallet_id).expect("wallet present");
+        let tracked = info
+            .tracked_asset_locks
+            .get(&out_point)
+            .expect("the broadcast lock is tracked");
+        assert!(
+            tracked.transaction.input.len() >= 2,
+            "a lock above either family's balance needs inputs from both, got {}",
+            tracked.transaction.input.len()
+        );
+    }
+
+    /// The DashPay half of the pooled set, end to end: a lock larger than
+    /// BIP44 alone holds reaches into a real contact-receiving account and
+    /// signs its inputs (DIP-15 `Normal256` path). Without this, every lookup
+    /// in the pooled path could resolve `None` for contact accounts and the
+    /// feature would silently degrade to BIP44 + BIP32.
+    #[tokio::test]
+    async fn pooled_asset_lock_spends_dashpay_contact_funds() {
+        let (wallet_manager, wallet_id, _generation, signer, _contact_account) =
+            funded_wallet_manager_with_contact(&[700_000], &[700_000]).await;
+        let (manager, _persistence) = asset_lock_manager_over(
+            wallet_manager,
+            wallet_id,
+            Arc::new(CountingOkBroadcaster::default()),
+        );
+
+        let (_path, out_point) = manager
+            .broadcast_funded_asset_lock(
+                1_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &signer,
+            )
+            .await
+            .expect("a lock above BIP44's balance must reach the contact account");
+
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm.get_wallet_and_info(&wallet_id).expect("wallet present");
+        let tracked = info
+            .tracked_asset_locks
+            .get(&out_point)
+            .expect("the broadcast lock is tracked");
+        assert!(
+            tracked.transaction.input.len() >= 2,
+            "the contact's coin must be spent alongside BIP44's"
+        );
+    }
+
+    /// The reservation hazard pooling introduces, and the one this change had
+    /// to get right: a rejected broadcast must release the reservation in
+    /// EVERY contributing account. The pooled build reserves per account under
+    /// one owner token, so releasing only the first would leave the rest of
+    /// the inputs held until the 24-block TTL backstop — and an immediate
+    /// retry would fail with spurious insufficient funds. The rebuild below
+    /// can only succeed if both families' inputs came back.
+    #[tokio::test]
+    async fn rejected_pooled_broadcast_releases_every_contributing_account() {
+        let (wallet_manager, wallet_id, _generation, signer) =
+            funded_wallet_manager_dual_standard(&[700_000], &[700_000]).await;
+        let (manager, _persistence) = asset_lock_manager_over(
+            wallet_manager,
+            wallet_id,
+            Arc::new(AlwaysRejectedBroadcaster),
+        );
+
+        let rejected = manager
+            .create_funded_asset_lock_proof(
+                1_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &signer,
+            )
+            .await;
+        assert!(
+            matches!(rejected, Err(PlatformWalletError::TransactionBroadcast(_))),
+            "the pooled build must have succeeded and only the broadcast failed, got {rejected:?}"
+        );
+        {
+            let wm = manager.wallet_manager.read().await;
+            let (_, info) = wm.get_wallet_and_info(&wallet_id).expect("wallet present");
+            assert!(
+                info.tracked_asset_locks.is_empty(),
+                "a definitively rejected lock leaves no resumable row"
+            );
+        }
+
+        // Identical rebuild: only possible if BOTH accounts' inputs were
+        // released. A release that reached only the first funding account
+        // would strand the other family's coin, leaving 700_000 available
+        // against a 1_000_000 lock — insufficient funds, not a rebuild.
+        let (rebuilt, _path) = manager
+            .build_asset_lock_transaction(
+                1_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &signer,
+            )
+            .await
+            .expect("every contributing account's reservation must have been released");
+        assert!(
+            rebuilt.input.len() >= 2,
+            "the rebuild must reselect inputs from both families, got {}",
+            rebuilt.input.len()
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -891,6 +891,22 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         if let Err(e) = pool_durability {
             tracing::error!(error = %e, "failed to persist asset-lock funding index");
             if funding_type == AssetLockFundingType::IdentityInvitation {
+                // The pooled build reserved every selected input across its
+                // contributing accounts under `reservation_token`. Nothing
+                // was broadcast, so abandon like the drain-floor branch
+                // above: drop the serialization guard, owner-release across
+                // every contributor, THEN surface the durability error —
+                // otherwise an immediate retry cannot reselect the BIP44 /
+                // BIP32 / DashPay inputs until the TTL sweep frees them.
+                drop(build_persist_guard);
+                crate::wallet::reservations::release_reservation_after_rejected_broadcast(
+                    &self.wallet_manager,
+                    &self.wallet_id,
+                    &funding_accounts,
+                    &tx,
+                    reservation_token,
+                )
+                .await;
                 return Err(PlatformWalletError::AssetLockTransaction(format!(
                     "aborted before broadcast: could not durably record the invitation \
                      funding index (broadcasting anyway would risk voucher-key reuse on \
@@ -1761,6 +1777,34 @@ mod tests {
                 >= 1,
             "the invitation gate must have driven flush()"
         );
+
+        // The abort released the pooled reservations across every
+        // contributing account: an IMMEDIATE rebuild must get through coin
+        // selection on the same fixture UTXOs and reach the durability gate
+        // again (the same "aborted before broadcast" error). Stranded
+        // reservations would surface here as a selection failure instead,
+        // stuck until the TTL sweep.
+        let rebuild = manager
+            .create_funded_asset_lock_proof(
+                1_000_000,
+                0,
+                AssetLockFundingType::IdentityInvitation,
+                0,
+                &signer,
+            )
+            .await;
+        match rebuild {
+            Err(PlatformWalletError::AssetLockTransaction(msg)) => assert!(
+                msg.contains("aborted before broadcast"),
+                "the rebuild must reselect the released inputs and reach the \
+                 durability gate again — a selection failure means the abort \
+                 stranded the pooled reservations; got: {msg}"
+            ),
+            other => panic!(
+                "the rebuild must reach the durability gate again (inputs \
+                 released), got {other:?}"
+            ),
+        }
     }
 
     /// Non-invitation funding types stay best-effort: their one-time keys

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
@@ -121,16 +121,24 @@ pub enum AssetLockFunding {
     /// - `AssetLockAddressTopUp` — for platform-address funding flows
     /// - others — see [`AssetLockFundingType`]
     ///
-    /// `account_index` selects which BIP44 *standard* account (by
-    /// BIP44 account index) supplies the UTXOs. This exact-amount form
-    /// is BIP44-only; CoinJoin funding exists solely as the
-    /// whole-balance [`AssetLockFunding::DrainAccountBalance`] form
-    /// (CoinJoin accounts have no change semantics). BIP32 funding
-    /// remains unsupported.
+    /// Funding is POOLED across `ASSET_LOCK_FUNDING_SOURCES`: coin
+    /// selection draws from the union of the BIP44 and BIP32 accounts at
+    /// `account_index` and every DashPay contact-receiving account, so
+    /// the lock does not need its whole amount sitting in one account.
+    /// Change returns to BIP44, the first source. Sources this wallet has
+    /// nothing for are skipped.
+    ///
+    /// CoinJoin is deliberately not in that set — spending mixed outputs
+    /// alongside transparent ones links them and undoes the mixing — so
+    /// CoinJoin funding still exists solely as the whole-balance
+    /// [`AssetLockFunding::DrainAccountBalance`] form (those accounts
+    /// also have no change semantics).
     FromWalletBalance {
         /// Amount to lock (in duffs).
         amount_duffs: u64,
-        /// BIP44 standard-account index to draw the funding UTXOs from.
+        /// Index addressing the standard (BIP44/BIP32) families of the
+        /// pooled source set. DashPay contact-receiving accounts span
+        /// their own indices and are pooled in regardless.
         account_index: u32,
     },
 

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/sync/proof.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/sync/proof.rs
@@ -45,28 +45,39 @@ pub(super) fn record_or_persister(
 }
 
 /// Family-aware in-memory funding-tx record lookup, shared by EVERY proof,
-/// ChainLock-wait, and recovery path. `TrackedAssetLock.account_index` is
-/// family-less (it doesn't record whether the lock was BIP44- or
-/// CoinJoin-funded), and key-wallet files a transaction that spends CoinJoin
-/// inputs under `coinjoin_accounts` — so a BIP44-only lookup leaves a
-/// whole-balance drain lock's IS/CL record invisible (fatal on hosts running
-/// `NoPlatformPersistence`, whose persister fallback always returns `None`).
-/// BIP44 is checked first (every historical lock), then CoinJoin.
+/// ChainLock-wait, and recovery path.
+///
+/// `TrackedAssetLock.account_index` is family-less — it records the source
+/// index, not which accounts ended up funding the lock — while key-wallet files
+/// a transaction under *every* account its inputs touch. So the record can sit
+/// in any of the families a lock may be funded from, and looking in only some
+/// of them leaves it invisible (fatal on hosts running `NoPlatformPersistence`,
+/// whose persister fallback always returns `None`, and a burnt proof-wait
+/// timeout everywhere else).
+///
+/// Two shapes make that a live concern: a whole-balance CoinJoin drain files
+/// only under `coinjoin_accounts`, and a POOLED asset lock
+/// (`ASSET_LOCK_FUNDING_SOURCES`) may take nothing from BIP44 and be funded
+/// entirely out of the BIP32 account or a DashPay contact-receiving one. All
+/// four families are therefore checked: the standard pair and CoinJoin at
+/// `account_index`, then the DashPay receiving accounts, which span their own
+/// indices and so are searched by txid alone. BIP44 stays first — it holds
+/// every historical lock.
 pub(in crate::wallet::asset_lock) fn funding_tx_record(
     accounts: &key_wallet::account::ManagedAccountCollection,
     account_index: u32,
     txid: &Txid,
 ) -> Option<TransactionRecord> {
-    accounts
-        .standard_bip44_accounts
-        .get(&account_index)
-        .and_then(|a| a.transactions().get(txid).cloned())
-        .or_else(|| {
-            accounts
-                .coinjoin_accounts
-                .get(&account_index)
-                .and_then(|a| a.transactions().get(txid).cloned())
-        })
+    let at_index = [
+        accounts.standard_bip44_accounts.get(&account_index),
+        accounts.standard_bip32_accounts.get(&account_index),
+        accounts.coinjoin_accounts.get(&account_index),
+    ];
+    at_index
+        .into_iter()
+        .flatten()
+        .chain(accounts.dashpay_receival_accounts.values())
+        .find_map(|account| account.transactions().get(txid).cloned())
 }
 
 /// Variant of [`record_or_persister`] that swallows persister errors

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/sync/proof.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/sync/proof.rs
@@ -656,6 +656,164 @@ mod tests {
         assert_eq!(found.txid, txid);
     }
 
+    /// BIP32-family regression for [`funding_tx_record`]: a POOLED asset
+    /// lock (`ASSET_LOCK_FUNDING_SOURCES`) may take nothing from BIP44 and
+    /// be funded entirely out of the BIP32 account, filing the record only
+    /// under `standard_bip32_accounts` — the lookup must still see it.
+    #[test]
+    fn funding_tx_record_finds_bip32_only_record() {
+        use key_wallet::test_utils::TestWalletContext;
+
+        let mut ctx = TestWalletContext::new_random();
+        let record = bip32_record_with_txid(0x55);
+        let txid = record.txid;
+        ctx.managed_wallet
+            .first_bip32_managed_account_mut()
+            .expect("default wallet has BIP32 account 0")
+            .transactions_mut()
+            .insert(txid, record);
+
+        let found = funding_tx_record(&ctx.managed_wallet.accounts, 0, &txid)
+            .expect("BIP32-family record must be found by the shared lookup");
+        assert_eq!(found.txid, txid);
+
+        // Unknown txid and unknown account index are clean misses.
+        assert!(
+            funding_tx_record(&ctx.managed_wallet.accounts, 0, &Txid::from([0x02; 32])).is_none()
+        );
+        assert!(funding_tx_record(&ctx.managed_wallet.accounts, 9, &txid).is_none());
+    }
+
+    /// DashPay-family regression for [`funding_tx_record`]: the receiving
+    /// accounts span their own indices, so the lookup searches them by txid
+    /// alone. A record filed only under a contact-receiving account whose
+    /// OWN index (7) differs from the tracked source `account_index` (0)
+    /// must still be found.
+    #[test]
+    fn funding_tx_record_finds_dashpay_receival_record_across_indices() {
+        use key_wallet::account::account_collection::DashpayAccountKey;
+        use key_wallet::managed_account::address_pool::{AddressPool, AddressPoolType, KeySource};
+        use key_wallet::managed_account::ManagedCoreFundsAccount;
+        use key_wallet::test_utils::TestWalletContext;
+        use key_wallet::{DerivationPath, ManagedAccountType, Network};
+
+        let mut ctx = TestWalletContext::new_random();
+
+        let user_identity_id = [0xAB; 32];
+        let friend_identity_id = [0xCD; 32];
+        let addresses = AddressPool::new(
+            DerivationPath::master(),
+            AddressPoolType::Absent,
+            20,
+            Network::Testnet,
+            &KeySource::NoKeySource,
+        )
+        .expect("single DashPay address pool");
+        let mut account = ManagedCoreFundsAccount::new(
+            ManagedAccountType::DashpayReceivingFunds {
+                index: 7,
+                user_identity_id,
+                friend_identity_id,
+                addresses,
+            },
+            Network::Testnet,
+        );
+
+        let record = dashpay_record_with_txid(0x66, 7, user_identity_id, friend_identity_id);
+        let txid = record.txid;
+        account.transactions_mut().insert(txid, record);
+        ctx.managed_wallet
+            .accounts
+            .dashpay_receival_accounts
+            .insert(
+                DashpayAccountKey {
+                    index: 7,
+                    user_identity_id,
+                    friend_identity_id,
+                },
+                account,
+            );
+
+        // The tracked source index (0) does not match the account's own
+        // index (7), yet the record is found — DashPay receiving accounts
+        // are searched by txid, not by the tracked source index.
+        let found = funding_tx_record(&ctx.managed_wallet.accounts, 0, &txid)
+            .expect("DashPay receival record must be found regardless of account_index");
+        assert_eq!(found.txid, txid);
+
+        // Even an account_index matching no account in any family still
+        // resolves the DashPay record — the search is index-independent.
+        let found_any_index = funding_tx_record(&ctx.managed_wallet.accounts, 9, &txid)
+            .expect("DashPay lookup is index-independent");
+        assert_eq!(found_any_index.txid, txid);
+
+        // Unknown txid is still a clean miss.
+        assert!(
+            funding_tx_record(&ctx.managed_wallet.accounts, 0, &Txid::from([0x03; 32])).is_none()
+        );
+    }
+
+    /// [`record_with_txid`] sibling filed as a BIP32-account record.
+    fn bip32_record_with_txid(seed: u8) -> TransactionRecord {
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: dashcore::OutPoint::new(Txid::from([seed; 32]), 0),
+                ..Default::default()
+            }],
+            output: Vec::new(),
+            special_transaction_payload: None,
+        };
+        TransactionRecord::new(
+            tx,
+            AccountType::Standard {
+                index: 0,
+                standard_account_type: StandardAccountType::BIP32Account,
+            },
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            Vec::new(),
+            Vec::new(),
+            0,
+        )
+    }
+
+    /// [`record_with_txid`] sibling filed as a DashPay contact-receiving
+    /// account record.
+    fn dashpay_record_with_txid(
+        seed: u8,
+        index: u32,
+        user_identity_id: [u8; 32],
+        friend_identity_id: [u8; 32],
+    ) -> TransactionRecord {
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: dashcore::OutPoint::new(Txid::from([seed; 32]), 0),
+                ..Default::default()
+            }],
+            output: Vec::new(),
+            special_transaction_payload: None,
+        };
+        TransactionRecord::new(
+            tx,
+            AccountType::DashpayReceivingFunds {
+                index,
+                user_identity_id,
+                friend_identity_id,
+            },
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            Vec::new(),
+            Vec::new(),
+            0,
+        )
+    }
+
     /// [`record_with_txid`] sibling filed as a CoinJoin-account record.
     fn coinjoin_record_with_txid(seed: u8) -> TransactionRecord {
         let tx = Transaction {

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/sync/reconstruction.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/sync/reconstruction.rs
@@ -153,18 +153,23 @@ fn chain_proof(
     }
 }
 
-/// Find the fund-bearing account (BIP44 first, then CoinJoin — same
-/// family order as `funding_tx_record` in `sync::proof`) that also
-/// recorded `txid`, i.e. the account whose UTXOs funded the asset
-/// lock. Falls back to 0 when no sibling record exists (the lookup
-/// paths that consume `account_index` degrade to the persister
-/// fallback on a miss, so a wrong-but-plausible index only costs a
-/// round-trip).
+/// Find the fund-bearing account (BIP44, then BIP32, then CoinJoin —
+/// the same family order as `funding_tx_record` in `sync::proof`) that
+/// also recorded `txid`, i.e. the account whose UTXOs funded the asset
+/// lock. A pooled build can be funded EXCLUSIVELY from a BIP32 account
+/// at a nonzero index; omitting that family here stored the fallback 0,
+/// and the pre-final proof wait then queried an index that holds no
+/// record — with `NoPlatformPersistence` there is no fallback, so the
+/// wait parked forever even after finality. Falls back to 0 only when
+/// no sibling record exists in ANY searched family (the lookup paths
+/// that consume `account_index` degrade to the persister fallback on a
+/// miss, so a wrong-but-plausible index only costs a round-trip).
 fn funding_account_index(info: &PlatformWalletInfo, txid: &dashcore::Txid) -> u32 {
     let accounts = &info.core_wallet.accounts;
     accounts
         .standard_bip44_accounts
         .iter()
+        .chain(accounts.standard_bip32_accounts.iter())
         .chain(accounts.coinjoin_accounts.iter())
         .find(|(_, account)| account.transactions().contains_key(txid))
         .map(|(index, _)| *index)
@@ -526,6 +531,78 @@ mod tests {
             .await
             .expect("build asset lock");
         (wallet_manager, wallet_id, tx)
+    }
+
+    /// A lock funded EXCLUSIVELY from a BIP32 account at a NONZERO index
+    /// must recover that index. The pre-fix inference searched only BIP44
+    /// and CoinJoin, stored the fallback 0, and the pre-final proof wait
+    /// then queried an index holding no record — with
+    /// `NoPlatformPersistence` there is no fallback, so the wait parked
+    /// forever even after finality.
+    #[test]
+    fn funding_account_index_recovers_nonzero_bip32_index() {
+        use std::collections::BTreeMap;
+
+        use key_wallet::managed_account::address_pool::{AddressPool, AddressPoolType, KeySource};
+        use key_wallet::managed_account::ManagedCoreFundsAccount;
+        use key_wallet::test_utils::TestWalletContext;
+        use key_wallet::{DerivationPath, ManagedAccountType};
+
+        use crate::wallet::core::WalletGeneration;
+        use crate::wallet::identity::IdentityManager;
+
+        let mut ctx = TestWalletContext::new_random();
+        let pool = || {
+            AddressPool::new(
+                DerivationPath::master(),
+                AddressPoolType::Absent,
+                20,
+                Network::Testnet,
+                &KeySource::NoKeySource,
+            )
+            .expect("address pool")
+        };
+        let mut account = ManagedCoreFundsAccount::new(
+            ManagedAccountType::Standard {
+                index: 7,
+                standard_account_type: StandardAccountType::BIP32Account,
+                external_addresses: pool(),
+                internal_addresses: pool(),
+            },
+            Network::Testnet,
+        );
+
+        let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[5_000]);
+        let txid = tx.txid();
+        account.transactions_mut().insert(
+            txid,
+            record_for(
+                &tx,
+                AccountType::Standard {
+                    index: 7,
+                    standard_account_type: StandardAccountType::BIP32Account,
+                },
+                chainlocked_context(9),
+            ),
+        );
+        ctx.managed_wallet
+            .accounts
+            .standard_bip32_accounts
+            .insert(7, account);
+
+        let info = PlatformWalletInfo {
+            core_wallet: ctx.managed_wallet,
+            generation: std::sync::Arc::new(WalletGeneration::new()),
+            identity_manager: IdentityManager::new(),
+            tracked_asset_locks: BTreeMap::new(),
+            dpns_name_states: BTreeMap::new(),
+        };
+        assert_eq!(
+            funding_account_index(&info, &txid),
+            7,
+            "the BIP32 sibling record identifies the true source index; \
+             falling back to 0 parks the proof wait forever"
+        );
     }
 
     fn chainlocked_context(height: u32) -> TransactionContext {

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/tracked.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/tracked.rs
@@ -110,7 +110,12 @@ pub struct TrackedAssetLock {
     /// The outpoint identifying this credit output (txid + vout).
     pub out_point: OutPoint,
     pub transaction: Transaction,
-    /// BIP44 account index that funded this asset lock (UTXO source).
+    /// Index the funding sources were resolved at — the standard
+    /// (BIP44/BIP32) family index handed to the build. NOT a record of
+    /// which accounts ended up supplying inputs: funding is pooled, so a
+    /// lock can be funded wholly out of a DashPay contact account, which
+    /// carries an index of its own. Consumers that need the funding
+    /// transaction search every family (see `funding_tx_record`).
     pub account_index: u32,
     pub funding_type: AssetLockFundingType,
     pub identity_index: u32,

--- a/packages/rs-platform-wallet/src/wallet/core/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/core/mod.rs
@@ -10,5 +10,5 @@ pub mod wallet;
 pub use balance::WalletBalance;
 pub use balance_handler::BalanceUpdateHandler;
 pub use generation::WalletGeneration;
-pub use transaction::{SignedCoreTransaction, SEND_FUNDING_SOURCES};
+pub use transaction::{SignedCoreTransaction, ASSET_LOCK_FUNDING_SOURCES, SEND_FUNDING_SOURCES};
 pub use wallet::CoreWallet;

--- a/packages/rs-platform-wallet/src/wallet/core/transaction.rs
+++ b/packages/rs-platform-wallet/src/wallet/core/transaction.rs
@@ -242,6 +242,23 @@ pub const SEND_FUNDING_SOURCES: [AccountTypePreference; 3] = [
     AccountTypePreference::AllDashpayReceivingFunds,
 ];
 
+/// The funding sources an **asset lock** pools by default — the same set, and
+/// for the same reasons, as [`SEND_FUNDING_SOURCES`]: an invitation, identity
+/// registration or top-up draws from the union of the standard families and
+/// every DashPay contact-receiving account, with change returning to BIP44.
+///
+/// Before this, an asset lock could only be funded from one BIP44 account, so a
+/// wallet holding its balance across several accounts had to sweep them into
+/// that account first and lock out of it — an extra on-chain hop, an extra fee,
+/// and a transparent address reused for the privilege. Pooling ends that
+/// sweep-then-lock shape.
+///
+/// CoinJoin is absent here for a second reason on top of the linkage one:
+/// upstream rejects a CoinJoin source pooled with any other, and CoinJoin
+/// asset-lock funding is drain-only. That flow keeps naming its single account,
+/// through `AssetLockBuildAmount::DrainAll`.
+pub const ASSET_LOCK_FUNDING_SOURCES: [AccountTypePreference; 3] = SEND_FUNDING_SOURCES;
+
 /// The concrete accounts `preference` resolves to at `source_index` — the
 /// platform mirror of key-wallet's private `account_types_for`: the single
 /// account at `source_index` for the standard families, and every DashPay

--- a/packages/rs-platform-wallet/src/wallet/identity/network/invitation.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/invitation.rs
@@ -265,7 +265,12 @@ impl IdentityWallet {
 
         // Build + broadcast the voucher asset lock at the invitation funding
         // account (the builder auto-selects the next unused funding index and
-        // returns its derivation path). `identity_index` is unused for the
+        // returns its derivation path). The DASH backing it is POOLED across
+        // `ASSET_LOCK_FUNDING_SOURCES` — the BIP44 and BIP32 accounts at
+        // `funding_account_index` plus every DashPay contact-receiving account
+        // — so an invitation can be funded from a balance spread across
+        // accounts, without the sweep-then-lock hop that used to be required.
+        // `identity_index` is unused for the
         // `IdentityInvitation` funding type. Only the broadcast half runs here —
         // the proof wait is deferred until AFTER the invitation record below is
         // durably persisted, so an interruption during the (potentially long)

--- a/packages/rs-platform-wallet/src/wallet/identity/network/top_up.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/top_up.rs
@@ -30,9 +30,12 @@ impl IdentityWallet {
     ///
     /// * `identity_id` - The identifier of the identity to top up.
     /// * `amount_duffs` - Amount of Dash (in duffs) to add.
-    /// * `account_index` - BIP44 standard-account index to draw the
-    ///   funding UTXOs from. Only BIP44 standard accounts are
-    ///   supported today (CoinJoin / BIP32 are out of scope).
+    /// * `account_index` - Index addressing the standard (BIP44/BIP32)
+    ///   families of the pooled funding set. The top-up draws from the
+    ///   union of those two accounts and every DashPay contact-receiving
+    ///   account (which span their own indices); CoinJoin stays out of
+    ///   the pool, since mixing it with transparent coins in one
+    ///   transaction would undo the mixing.
     /// * `asset_lock_signer` - External ECDSA signer that produces both
     ///   the funding-input P2PKH signatures during asset-lock build and
     ///   the consume-phase outer signature on the IdentityTopUp

--- a/packages/rs-platform-wallet/src/wallet/reservations.rs
+++ b/packages/rs-platform-wallet/src/wallet/reservations.rs
@@ -1,11 +1,13 @@
 //! Broadcast-side UTXO reservation cleanup.
 //!
-//! `TransactionBuilder::build_signed` reserves the selected UTXOs in the
-//! funding account's `ReservationSet` and leaves the reservation held on
-//! success, expecting the transaction to be broadcast. When the broadcast
-//! *fails* the reservation must be reconciled here: released for an immediate
-//! retry when Core definitively rejected the transaction, kept (for the
-//! reservation-TTL backstop or a later sync) when acceptance is unknown.
+//! `TransactionBuilder::build_signed` reserves the selected UTXOs in each
+//! contributing funding account's `ReservationSet` and leaves the reservation
+//! held on success, expecting the transaction to be broadcast. When the
+//! broadcast *fails* the reservation must be reconciled here: released for an
+//! immediate retry when Core definitively rejected the transaction, kept (for
+//! the reservation-TTL backstop or a later sync) when acceptance is unknown.
+//! A pooled build reserves across several accounts under one owner token, so
+//! the reconciliation takes the whole contributor list, not one account.
 //!
 //! Every build-then-broadcast path must go through
 //! [`broadcast_releasing_on_rejection`] so the cleanup exists once instead of
@@ -16,6 +18,7 @@
 
 use dashcore::{Transaction, Txid};
 use key_wallet::account::account_type::StandardAccountType;
+use key_wallet::account::AccountType;
 use key_wallet_manager::WalletManager;
 use tokio::sync::RwLock;
 
@@ -54,7 +57,10 @@ pub(crate) async fn broadcast_releasing_on_rejection<B: TransactionBroadcaster +
                 release_reservation_after_rejected_broadcast(
                     wallet_manager,
                     wallet_id,
-                    ReservedFundingAccount::Standard(account_type, account_index),
+                    &[AccountType::Standard {
+                        index: account_index,
+                        standard_account_type: account_type,
+                    }],
                     tx,
                     // The generic send path doesn't thread the build's
                     // reservation token yet; keep its historical
@@ -68,20 +74,15 @@ pub(crate) async fn broadcast_releasing_on_rejection<B: TransactionBroadcaster +
     }
 }
 
-/// The funding account whose `ReservationSet` holds a transaction's inputs —
-/// the same account handed to `set_funding` when the transaction was built.
-/// Asset locks can be funded from a CoinJoin account (the whole-balance
-/// drain flow), so the release path must address that family too.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum ReservedFundingAccount {
-    /// A standard (BIP44/BIP32) account at the given index.
-    Standard(StandardAccountType, u32),
-    /// A CoinJoin account at the given index.
-    CoinJoin(u32),
-}
-
-/// Release the funding account's UTXO reservation for `tx` after its
+/// Release the funding accounts' UTXO reservations for `tx` after its
 /// broadcast came back [`BroadcastError::Rejected`].
+///
+/// `funding_accounts` are the accounts that contributed inputs to `tx` — the
+/// accounts handed to `add_funding` when it was built. A build funded from
+/// several of them (a pooled asset lock, a pooled send) reserves in **each**
+/// account's own `ReservationSet` under the one token, so every one of them
+/// must reconcile; releasing only the first would leave the rest of the inputs
+/// held until the TTL backstop reclaims them.
 ///
 /// Callers that pair the release with other rejection cleanup must order
 /// that cleanup **before** this call when it removes state a concurrent
@@ -91,7 +92,7 @@ pub(crate) enum ReservedFundingAccount {
 pub(crate) async fn release_reservation_after_rejected_broadcast(
     wallet_manager: &RwLock<WalletManager<PlatformWalletInfo>>,
     wallet_id: &WalletId,
-    funding_account: ReservedFundingAccount,
+    funding_accounts: &[AccountType],
     tx: &Transaction,
     reservation_token: Option<key_wallet::ReservationToken>,
 ) {
@@ -99,40 +100,33 @@ pub(crate) async fn release_reservation_after_rejected_broadcast(
     // untouched, so a read lock suffices — this cleanup does not
     // serialize concurrent sends.
     let wm = wallet_manager.read().await;
-    let account = wm
-        .get_wallet_and_info(wallet_id)
-        .and_then(|(_, info)| match funding_account {
-            ReservedFundingAccount::Standard(StandardAccountType::BIP44Account, account_index) => {
-                info.core_wallet
-                    .bip44_managed_account_at_index(account_index)
-            }
-            ReservedFundingAccount::Standard(StandardAccountType::BIP32Account, account_index) => {
-                info.core_wallet
-                    .bip32_managed_account_at_index(account_index)
-            }
-            ReservedFundingAccount::CoinJoin(account_index) => info
-                .core_wallet
-                .accounts
-                .coinjoin_accounts
-                .get(&account_index),
-        });
-    match account {
-        // Owner-guarded when the build's `ReservationToken` is available:
-        // this cleanup always runs after `.await`s (build → broadcast), so
-        // the original reservation may have been swept and the same
-        // outpoints re-reserved by a NEWER build — an unconditional release
-        // would clobber that newer owner and make its inputs re-selectable
-        // by a conflicting transaction. Callers without a token (paths that
-        // predate token plumbing) keep the historical unconditional release.
-        Some(account) => match reservation_token {
-            Some(token) => account.release_reservation_if_owner(tx, token),
-            None => account.release_reservation(tx),
-        },
-        None => tracing::warn!(
+    let Some((_, info)) = wm.get_wallet_and_info(wallet_id) else {
+        tracing::warn!(
             wallet_id = %hex::encode(wallet_id),
-            ?funding_account,
-            "could not release UTXO reservation after rejected broadcast: \
-             wallet or funds account not found"
-        ),
+            ?funding_accounts,
+            "could not release UTXO reservation after rejected broadcast: wallet not found"
+        );
+        return;
+    };
+    for funding_account in funding_accounts {
+        match info.core_wallet.accounts.funds_account(funding_account) {
+            // Owner-guarded when the build's `ReservationToken` is available:
+            // this cleanup always runs after `.await`s (build → broadcast), so
+            // the original reservation may have been swept and the same
+            // outpoints re-reserved by a NEWER build — an unconditional release
+            // would clobber that newer owner and make its inputs re-selectable
+            // by a conflicting transaction. Callers without a token (paths that
+            // predate token plumbing) keep the historical unconditional release.
+            Some(account) => match reservation_token {
+                Some(token) => account.release_reservation_if_owner(tx, token),
+                None => account.release_reservation(tx),
+            },
+            None => tracing::warn!(
+                wallet_id = %hex::encode(wallet_id),
+                ?funding_account,
+                "could not release UTXO reservation after rejected broadcast: \
+                 funds account not found"
+            ),
+        }
     }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
@@ -658,10 +658,11 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - amountDuffs: Amount to lock in Core duffs.
-    ///   - fundingAccountIndex: BIP44 standard Core account whose UTXOs
-    ///     fund the asset lock. Today only BIP44 standard accounts are
-    ///     supported (CoinJoin / BIP32 not yet wired through the
-    ///     asset-lock builder).
+    ///   - fundingAccountIndex: standard-family source index — the asset
+    ///     lock POOLS the BIP44 and BIP32 accounts at that index together
+    ///     with every DashPay receiving account (change returns to BIP44);
+    ///     the index does not restrict which DashPay receiving accounts
+    ///     contribute. CoinJoin remains drain-only and separate.
     ///   - platformAccountIndex: Platform-payment account containing
     ///     `recipients`. Used for the membership pre-flight on the Rust
     ///     side and the post-success balance write.

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
@@ -3863,13 +3863,13 @@ extension ManagedPlatformWallet {
     /// `KeychainSigner`. Asset-lock proof is built Rust-side from
     /// `amountDuffs` (wallet must have spendable Core UTXOs).
     ///
-    /// `accountIndex` selects which BIP44 *standard* account (by
-    /// BIP44 account index) supplies the funding UTXOs. Only BIP44
-    /// standard accounts are supported today; the caller is
-    /// responsible for filtering its account picker accordingly —
-    /// CoinJoin / BIP32 funding for new-identity registration is not
-    /// yet wired through `create_funded_asset_lock_proof` on the Rust
-    /// side.
+    /// `accountIndex` addresses the *standard* families: the asset
+    /// lock POOLS the BIP44 and BIP32 accounts at that index together
+    /// with every DashPay contact-receiving account (change returns
+    /// to BIP44). The index does NOT restrict which DashPay receiving
+    /// accounts contribute, so the caller must not present it as an
+    /// account-scoped funding or privacy choice. CoinJoin funding
+    /// remains drain-only and is not reachable here.
     ///
     /// Caller MUST pre-derive `identityPubkeys` (typically via
     /// `dash_sdk_derive_identity_keys_from_mnemonic`) AND pre-persist

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
@@ -4091,9 +4091,12 @@ extension ManagedPlatformWallet {
     /// Simpler than registration: an `IdentityTopUp` creates no identity
     /// keys, so there is no per-identity-key `KeychainSigner` and no pubkey
     /// array — the transition is signed entirely by the asset lock's
-    /// Core-side key via a `MnemonicResolver`. `accountIndex` selects which
-    /// BIP44 *standard* account supplies the funding UTXOs (same constraint
-    /// as registration).
+    /// Core-side key via a `MnemonicResolver`. `accountIndex` addresses the
+    /// *standard* families: the asset lock POOLS the BIP44 and BIP32
+    /// accounts at that index together with every DashPay contact-receiving
+    /// account (change returns to BIP44), and does NOT restrict which
+    /// DashPay receiving accounts contribute — the same contract as
+    /// registration.
     ///
     /// `amountDuffs` must meet the Rust-side minimum top-up asset-lock
     /// balance; a smaller amount is rejected before any lock is broadcast

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
@@ -107,8 +107,10 @@ extension PlatformWalletManager {
     /// - Parameters:
     ///   - walletId: 32-byte wallet identifier (the same key
     ///     `bindShielded` uses to look up the bound subwallet).
-    ///   - fundingAccountIndex: BIP44 Core account whose UTXOs fund
-    ///     the asset lock.
+    ///   - fundingAccountIndex: standard-family index the asset lock
+    ///     funds from — POOLS the BIP44 and BIP32 accounts at that
+    ///     index with every DashPay receiving account (change returns
+    ///     to BIP44); it does not restrict DashPay contributions.
     ///   - amountDuffs: L1 amount to lock in Core duffs. Must be
     ///     large enough to cover `recipients.credits + Platform fee`;
     ///     undersized locks fail at Platform submission.
@@ -383,8 +385,10 @@ extension PlatformWalletManager {
     ///     each batch's real note (must be bound).
     ///   - targetTotalNotes: drive the on-chain pool note count up to (at
     ///     least) this value. A no-op if the pool already has this many.
-    ///   - fundingAccountIndex: Core BIP44 account whose UTXOs fund each
-    ///     per-batch asset lock.
+    ///   - fundingAccountIndex: standard-family index each per-batch
+    ///     asset lock funds from — POOLS the BIP44 and BIP32 accounts at
+    ///     that index with every DashPay receiving account (change
+    ///     returns to BIP44); it does not restrict DashPay contributions.
     ///   - progress: optional live-progress handler (see above).
     public func seedShieldedPoolNotes(
         walletId: Data,


### PR DESCRIPTION
## Issue being fixed or feature implemented

#4329 pooled the **send** path and left asset locks single-account. An invitation, identity registration or top-up could only be funded from ONE BIP44 account, so a wallet holding its balance across the standard families and its DashPay contact-receiving accounts had to **sweep them together first and lock out of the sweep** — an extra on-chain hop, an extra fee, and a transparent address reused for the privilege. On Android that sweep-then-lock shape is what users actually hit.

This is the approved follow-up: the same pooling, for asset locks.

**Depends on dashpay/rust-dashcore#935.** `Cargo.toml` is pinned to that branch's rev so CI here is honest about what it is testing; **the pin must be re-pointed to `dashpay/rust-dashcore` `dev` when #935 merges** — please don't merge this with the fork pin in place.

## What was done?

`ASSET_LOCK_FUNDING_SOURCES` (deliberately the same set as `SEND_FUNDING_SOURCES`: BIP44, BIP32, `AllDashpayReceivingFunds`) is now the default for asset-lock funding. Coin selection draws from the union, the first source supplies the change address so change returns to BIP44, and sources this wallet has nothing for — no BIP32 account, no contacts — are skipped rather than fatal.

`build_asset_lock_transaction_with_funding` and `broadcast_funded_asset_lock_with_funding` take the source list plus a `source_index` in place of a single `AssetLockFundingAccount`. The historical entry points — `build_asset_lock_transaction`, `broadcast_funded_asset_lock`, `create_funded_asset_lock_proof` — keep their exact signatures and just pass the pooled set, so **every call site above them becomes pooled with no new plumbing**: `create_invitation`, identity registration, top-up, platform-address and shielded funding, and the `asset_lock_manager_build_transaction` FFI export. Nothing gained an elective funding selector it does not need, and #4337's `build_asset_lock_transaction(…, account_index, …)` recovery helper call is unaffected.

### Reservation reconciliation — the part to review hardest

`release_reservation_after_rejected_broadcast` now takes the **contributing account list** instead of one `ReservedFundingAccount`. A pooled build reserves in each contributing account's own `ReservationSet` under the one owner token, so a release reaching only the first account would strand the rest of the inputs until the 24-block TTL backstop, and an immediate retry would fail with spurious insufficient funds. The build returns those accounts (upstream's `AssetLockResult::funding_accounts`, which is the *contributor* list — selection routinely takes nothing from most offered accounts, and a list naming every contact would make this scale with the address book), and **both** rejection paths — the undersized-drain abandon and the rejected broadcast — release across all of them, still owner-guarded (#4185).

`ReservedFundingAccount` is deleted: `AccountType` already names every family, including the DashPay accounts the old enum could not express at all.

### A lookup that had to widen with it

`funding_tx_record` resolved the funding transaction in BIP44 and CoinJoin **at the tracked index only**. key-wallet files a transaction under every account its inputs touch, and a pooled lock may take nothing from BIP44 — funded entirely out of BIP32 or a contact account. The lookup would miss it, which burns the proof wait and is outright fatal under `NoPlatformPersistence`, whose persister fallback always returns `None`. It now covers the standard pair and CoinJoin at the index, then the DashPay receiving accounts by txid (they span their own indices). This is the same class of gap #4336's CoinJoin fix closed, arriving here because pooling opens it.

`TrackedAssetLock.account_index` keeps its meaning as the *source* index and its persisted shape — no schema change — but its doc now says plainly that it is not a record of which accounts funded the lock.

### CoinJoin is untouched

Still drain-only, still a single account, now routed through `create_funded_asset_lock_proof_with_funding`, which converts it to a one-element source list. Upstream additionally rejects a CoinJoin source pooled with any other, since spending mixed outputs alongside transparent ones links them and undoes the mixing. #4327's flow and its `undersized_drain_abandoned_before_broadcast` test are unchanged.

### Docs that asserted the old invariant

`AssetLockFunding::FromWalletBalance` ("This exact-amount form is BIP44-only … BIP32 funding remains unsupported"), `top_up_identity`'s `account_index` ("Only BIP44 standard accounts are supported today"), and the invitation build comment all described the single-account world. They now describe the pooled one rather than silently contradicting the code.

## How Has This Been Tested?

`cargo test -p platform-wallet` — 613 lib tests + integration suites, 0 failures. `cargo check --workspace --all-targets` clean; `cargo clippy -p platform-wallet -p platform-wallet-ffi --all-targets -- -D warnings` clean; `cargo fmt` applied.

New tests, on the fixtures #4329 added for the pooled send:

- `pooled_asset_lock_spans_the_standard_families` — a 1,000,000-duff lock against two 700,000-duff accounts. Before pooling this was `CoreInsufficientFunds`.
- `pooled_asset_lock_spends_dashpay_contact_funds` — the same against a real `DashpayReceivingFunds` contact account, so the contact path cannot silently degrade to BIP44 + BIP32.
- `rejected_pooled_broadcast_releases_every_contributing_account` — the reservation hazard. A rejected pooled broadcast, then an identical rebuild that can only succeed if **both** families' inputs came back.

I checked that last one is not vacuous: with the release loop truncated to the first account it fails with `Insufficient funds: available 700000, required 1000000`, which is exactly the stranding it is meant to catch. The upstream siblings in #935 were mutation-checked the same way.

## Breaking Changes

Internal to the crate — no FFI signature changes, no persistence format change:

- `build_asset_lock_transaction_with_funding` / `broadcast_funded_asset_lock_with_funding` take `funding_sources: &[AccountTypePreference], source_index: u32`; the former also returns the contributing accounts.
- `create_funded_asset_lock_proof_with_funding` keeps `AssetLockFundingAccount` and is now explicitly the whole-balance drain form.
- `pub(crate) enum ReservedFundingAccount` removed in favour of `AccountType`.
- New export: `platform_wallet::ASSET_LOCK_FUNDING_SOURCES`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset-lock transactions can pool funds from BIP44, BIP32, and DashPay receiving accounts.
  * Change returns to BIP44, with contributing accounts tracked for recovery and cleanup.
  * Funding sources are available for wallet integrations.

* **Bug Fixes**
  * Improved reservation cleanup and retry handling for multi-account funding.
  * Improved recovery of funding transactions and account indexes.

* **Documentation**
  * Clarified pooled funding, account indexes, recovery, and identity funding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->