### PR TITLE
fix(platform-wallet): raise the invitation cap to cover the contested username tier

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/identity/network/invitation.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/invitation.rs
@@ -45,15 +45,19 @@ use crate::wallet::identity::network::contact_requests::ContactCryptoProvider;
 
 use super::*;
 
-/// Hard cap on the amount an invitation can lock (0.05 DASH). The voucher is a
+/// Hard cap on the amount an invitation can lock (0.26 DASH). The voucher is a
 /// bearer credential, so the blast radius of a leaked link is bounded here in
-/// Rust — not just in the UI. Sized for onboarding: the invitee spends the
-/// voucher on identity creation **plus** a normal DPNS name (~0.03 DASH — the
-/// legacy `DASH_PAY_FEE`), so the previous 0.01 cap was actually below a usable
-/// invitation and rejected its own onboarding default. The contested/premium-name
-/// tier (~0.25 DASH) is deferred until contested-name-via-invite claim exists;
-/// raise this cap when it does.
-pub const MAX_INVITATION_DUFFS: u64 = 5_000_000;
+/// Rust — not just in the UI. Sized for onboarding at BOTH username tiers: the
+/// invitee spends the voucher on identity creation **plus** a DPNS name — a
+/// normal name (~0.03 DASH, the legacy `DASH_PAY_FEE`) or a contested/premium
+/// name (~0.25 DASH, `DASH_PAY_FEE_CONTESTED`), with the 0.01 margin covering
+/// the create/claim fees. The earlier 0.05 value deferred the contested tier
+/// "until contested-name-via-invite claim exists" — the claim path is
+/// amount-agnostic and contested-invite claims are verified working, and the
+/// Android wallet has funded contested invitations at 0.25 since 2024, so the
+/// deferral is over. (The pre-merge 0.01 iteration was below even a usable
+/// non-contested invitation and rejected its own onboarding default.)
+pub const MAX_INVITATION_DUFFS: u64 = 26_000_000;
 
 /// Floor on the amount an invitation can lock (0.003 DASH). A voucher funds a
 /// Platform identity operation, and creating an identity — which is what the


### PR DESCRIPTION
## Required for existing Android functionality

The Android wallet has funded contested (premium-name) invitations at **0.25 DASH** since 2024 (`DASH_PAY_FEE_CONTESTED`, dash-wallet `Constants.java:332`). Its legacy dashj invitation path imposes no cap, so contested invitations have always worked pre-cutover. The moment a wallet commits the dashj→SDK cutover, `create_invitation` becomes the only route — and every contested invitation is rejected pre-broadcast:

```
Invalid identity data: invitation amount 25000000 exceeds the cap 5000000 duffs
```

Observed on a device 2026-08-09 as an endless confirm/retry loop (the app-side loop is fixed separately; the capability gap is this cap). A contested L1 invitation has **never** succeeded through the SDK path — the 0.25-vs-0.05 contradiction has existed since the path was first wired.

## Why raising is safe and sanctioned

- The constant's own doc deferred the contested tier *"until contested-name-via-invite claim exists; raise this cap when it does."* That condition is met: `claim_invitation` is amount-agnostic (no cap at claim), and contested-invite claims are verified working in QA.
- The cap is a **client-side leaked-link bound, not consensus** — registration/top-up have no equivalent.
- Both the dashj legacy path and the shielded invitation path already mint 0.25 bearer links today, so 0.05 on this one path protected nothing while breaking path parity post-cutover.

**0.26** = the 0.25 contested fee + margin for the create/claim fees, matching the Android wallet's rounded contested guidance. `MIN_INVITATION_DUFFS` and all boundary tests are relative to the constant and unchanged; `platform-wallet` lib: 610 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum invitation funding limit to support both standard and contested DPNS-name onboarding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->