### PR TITLE
fix(platform-wallet): stop a contact's watch-only chain from defining the persisted transaction row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "dash-network",
 ]
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1805,12 +1805,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2475,7 +2475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2536,7 +2536,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 
 [[package]]
 name = "glob"
@@ -3840,7 +3840,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "aes",
  "async-trait",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5a80bd71f6ba13a5055780d644f0aa724a34ca04#5a80bd71f6ba13a5055780d644f0aa724a34ca04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4652,7 +4652,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5752,7 +5752,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6559,7 +6559,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6572,7 +6572,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6631,7 +6631,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7491,7 +7491,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8940,7 +8940,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "5a80bd71f6ba13a5055780d644f0aa724a34ca04" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
 
 tokio-metrics = "0.5"
 

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -618,7 +618,16 @@ async fn build_core_changeset(
             CoreChangeSet {
                 new_utxos: derive_new_utxos(record),
                 spent_utxos: derive_spent_utxos(record),
-                records: vec![(**record).clone()],
+                // A contact's watch-only chain never defines the
+                // wallet's transaction row (see `is_contact_watch_only`).
+                // The usage deltas below are still emitted, so the
+                // event is not dropped and the contact's address pool
+                // still advances.
+                records: if is_contact_watch_only(record) {
+                    Vec::new()
+                } else {
+                    vec![(**record).clone()]
+                },
                 // Mirror the upstream-emitted derived addresses
                 // through to the persister so newly-extended pool
                 // rows are written transactionally with the tx that
@@ -668,9 +677,20 @@ async fn build_core_changeset(
             // record's content does change though, so re-emit it.
             // Matured coinbase records likewise: no UTXO topology change,
             // just a status update for the persister.
-            cs.records.extend(inserted.iter().cloned());
-            cs.records.extend(updated.iter().cloned());
-            cs.records.extend(matured.iter().cloned());
+            //
+            // Contact watch-only records are filtered out of all three
+            // lists: re-emitting one on confirmation would re-clobber the
+            // funding account's row with an incoming/positive
+            // classification just as the first sighting did (see
+            // `is_contact_watch_only`).
+            cs.records.extend(
+                inserted
+                    .iter()
+                    .chain(updated.iter())
+                    .chain(matured.iter())
+                    .filter(|r| !is_contact_watch_only(r))
+                    .cloned(),
+            );
             cs.last_processed_height = Some(*height);
             // Pool extensions triggered by any record in this block.
             // Already deduped upstream by `project_derived_addresses`;
@@ -938,12 +958,72 @@ async fn is_chain_locked(
     false
 }
 
+/// Is this record owned by a contact's watch-only DashPay chain?
+///
+/// A `DashpayExternalAccount` derives its addresses from the
+/// **contact's** xpub, so this wallet can observe those outputs but can
+/// never sign for them. They are the contact's coins; this wallet only
+/// ever pays into them.
+///
+/// dashpay/rust-dashcore#926 established exactly that policy at the
+/// balance layer, dropping `dashpay_external_accounts` from
+/// `ManagedAccountCollection::all_funding_accounts` (and `_mut`), which
+/// covers `balance`, `account_balances`, `utxos` and
+/// `get_spendable_utxos` in one place. `dashpay_receival_accounts` were
+/// deliberately kept: those derive from *our* xpub, so a contact paying
+/// into them really is money arriving.
+///
+/// The persistence seam is the same rule's second home. Upstream
+/// `check_core_transaction` emits **one `TransactionRecord` per matched
+/// account** (`key_wallet::transaction_checking::wallet_checker`), so a
+/// payment to a contact produces two records sharing one txid:
+///
+/// | record's account          | `direction` | `net_amount`     |
+/// |---------------------------|-------------|------------------|
+/// | funding (BIP44/BIP32/…)   | `Outgoing`  | `change - spent` |
+/// | `DashpayExternalAccount`  | `Incoming`  | `+paid`          |
+///
+/// The external account's record is not *wrong* about its own account —
+/// that chain did receive an output. It is wrong as a description of the
+/// **wallet**, and the persisted `transactions` row is keyed by txid
+/// alone, with no per-account dimension to disambiguate (the
+/// `transaction_account_involvements` table is only written for
+/// provider-key accounts). Whichever record is stored last therefore
+/// defines the row, and the watch-only one — emitted last, because
+/// `all_accounts` visits the DashPay accounts after the standard ones —
+/// wins: a payment *away* is persisted as an incoming credit, and its
+/// output is written into `txos` as a wallet-owned coin no key of ours
+/// can spend.
+///
+/// So external-account records are excluded from the persist-time
+/// projection entirely, exactly as #926 excluded the accounts from
+/// balance aggregation. What survives from the same event is everything
+/// that is genuinely ours to remember: the address-used flips and
+/// highest-used watermarks (so contact address rotation keeps working),
+/// the derived-address rows, and `derive_spent_utxos` (so a contact
+/// spending an output persisted *before* this fix still clears the
+/// stale row).
+fn is_contact_watch_only(record: &TransactionRecord) -> bool {
+    matches!(
+        record.account_type,
+        AccountType::DashpayExternalAccount { .. }
+    )
+}
+
 /// Derive the "ours" UTXOs created by a transaction's outputs.
 ///
 /// Walks `record.output_details`, keeps entries with role `Received` or
 /// `Change`, and reconstructs a full `Utxo` from the corresponding
 /// `transaction.output[index]` plus the record's confirmation context.
+///
+/// Records belonging to a contact's watch-only chain yield nothing —
+/// see [`is_contact_watch_only`]. This is the direct counterpart of
+/// dashpay/rust-dashcore#926 dropping those accounts from `utxos()` /
+/// `get_spendable_utxos()`.
 fn derive_new_utxos(record: &TransactionRecord) -> Vec<Utxo> {
+    if is_contact_watch_only(record) {
+        return Vec::new();
+    }
     let height = record.context.block_info().map(|b| b.height()).unwrap_or(0);
     let is_confirmed = matches!(
         record.context,
@@ -1042,6 +1122,470 @@ impl CoreChangeSet {
             && self.addresses_derived.is_empty()
             && self.addresses_marked_used.is_empty()
             && self.account_highest_used.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod contact_watch_only_projection_tests {
+    //! Regression coverage for the persist-time projection of records
+    //! belonging to a contact's watch-only `DashpayExternalAccount`
+    //! (dashpay/rust-dashcore#926's policy at the persistence seam —
+    //! see [`is_contact_watch_only`]).
+    //!
+    //! Upstream emits one record per matched account, so these tests
+    //! build the record pair a real payment-to-a-contact produces and
+    //! assert on what [`build_core_changeset`] hands the persister:
+    //! the funding account's outgoing/negative row, and no wallet TXO
+    //! for the coin that landed on the contact's chain.
+
+    use super::*;
+    use dashcore::hashes::Hash;
+    use dashcore::{Address as DashAddress, BlockHash, Txid};
+    use dashcore::{OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Witness};
+    use key_wallet::account::{AccountType, StandardAccountType};
+    use key_wallet::managed_account::transaction_record::{
+        InputDetail, OutputDetail, TransactionDirection,
+    };
+    use key_wallet::transaction_checking::transaction_router::TransactionType;
+    use key_wallet::transaction_checking::BlockInfo;
+    use key_wallet::{Network, WalletCoreBalance};
+    use key_wallet_manager::WalletManager;
+
+    const WALLET_ID: WalletId = [9u8; 32];
+
+    /// Duffs, matching the testnet capture that surfaced this bug:
+    /// 1.0 DASH funded, 0.69998912 paid to the contact, 0.3 back as
+    /// change, 1088 duffs of fee. The wallet's true net is therefore
+    /// `-70_000_000`; the store held `+69_998_912`.
+    const FUNDING: u64 = 100_000_000;
+    const PAID_TO_CONTACT: u64 = 69_998_912;
+    const CHANGE: u64 = 30_000_000;
+
+    fn our_change_address() -> DashAddress {
+        DashAddress::dummy(Network::Testnet, 1)
+    }
+
+    fn our_receive_address() -> DashAddress {
+        DashAddress::dummy(Network::Testnet, 2)
+    }
+
+    /// An address on the contact's watch-only chain — derived from the
+    /// *contact's* xpub in production, so we can see it but never sign.
+    fn contact_address() -> DashAddress {
+        DashAddress::dummy(Network::Testnet, 3)
+    }
+
+    fn bip44_account_0() -> AccountType {
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        }
+    }
+
+    fn contact_external_account() -> AccountType {
+        AccountType::DashpayExternalAccount {
+            index: 0,
+            user_identity_id: [1u8; 32],
+            friend_identity_id: [2u8; 32],
+        }
+    }
+
+    fn in_block(height: u32) -> TransactionContext {
+        TransactionContext::InBlock(BlockInfo::new(
+            height,
+            BlockHash::from_slice(&[4u8; 32]).expect("valid block hash"),
+            1_234_567_890,
+        ))
+    }
+
+    fn funding_outpoint() -> OutPoint {
+        OutPoint {
+            txid: Txid::from_slice(&[5u8; 32]).expect("valid txid"),
+            vout: 0,
+        }
+    }
+
+    /// One input (our funding coin) and the given outputs, in order.
+    fn tx_with(outputs: &[(&DashAddress, u64)]) -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: funding_outpoint(),
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: Witness::new(),
+            }],
+            output: outputs
+                .iter()
+                .map(|(addr, value)| TxOut {
+                    value: *value,
+                    script_pubkey: addr.script_pubkey(),
+                })
+                .collect(),
+            special_transaction_payload: None,
+        }
+    }
+
+    /// The input detail upstream builds when the spent outpoint was one
+    /// of the account's own UTXOs.
+    fn our_input() -> InputDetail {
+        InputDetail {
+            index: 0,
+            value: FUNDING,
+            address: our_change_address(),
+        }
+    }
+
+    fn output(index: u32, role: OutputRole, address: &DashAddress, value: u64) -> OutputDetail {
+        OutputDetail {
+            index,
+            role,
+            address: Some(address.clone()),
+            value,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record(
+        tx: &Transaction,
+        account_type: AccountType,
+        direction: TransactionDirection,
+        input_details: Vec<InputDetail>,
+        output_details: Vec<OutputDetail>,
+        net_amount: i64,
+    ) -> TransactionRecord {
+        TransactionRecord::new(
+            tx.clone(),
+            account_type,
+            in_block(1_000),
+            TransactionType::Standard,
+            direction,
+            input_details,
+            output_details,
+            net_amount,
+        )
+    }
+
+    /// The record pair a payment to a contact really produces: the
+    /// funding account sees `Outgoing` with a negative net, and the
+    /// contact's watch-only chain independently sees `Incoming` with a
+    /// positive net for the very same txid.
+    ///
+    /// Output 0 pays the contact, output 1 is our change.
+    fn contact_payment_records() -> (Transaction, TransactionRecord, TransactionRecord) {
+        let tx = tx_with(&[
+            (&contact_address(), PAID_TO_CONTACT),
+            (&our_change_address(), CHANGE),
+        ]);
+        let funding = record(
+            &tx,
+            bip44_account_0(),
+            TransactionDirection::Outgoing,
+            vec![our_input()],
+            vec![
+                // Not ours as far as the funding account is concerned.
+                output(0, OutputRole::Sent, &contact_address(), PAID_TO_CONTACT),
+                output(1, OutputRole::Change, &our_change_address(), CHANGE),
+            ],
+            CHANGE as i64 - FUNDING as i64,
+        );
+        let watch_only = record(
+            &tx,
+            contact_external_account(),
+            TransactionDirection::Incoming,
+            // No inputs: this account owns none of the coins spent.
+            Vec::new(),
+            vec![output(
+                0,
+                OutputRole::Received,
+                &contact_address(),
+                PAID_TO_CONTACT,
+            )],
+            PAID_TO_CONTACT as i64,
+        );
+        (tx, funding, watch_only)
+    }
+
+    fn test_manager() -> Arc<RwLock<WalletManager<PlatformWalletInfo>>> {
+        Arc::new(RwLock::new(WalletManager::<PlatformWalletInfo>::new(
+            dashcore::Network::Testnet,
+        )))
+    }
+
+    fn block_processed(inserted: Vec<TransactionRecord>) -> WalletEvent {
+        WalletEvent::BlockProcessed {
+            wallet_id: WALLET_ID,
+            height: 1_000,
+            chain_lock: None,
+            inserted,
+            updated: vec![],
+            matured: vec![],
+            balance: WalletCoreBalance::default(),
+            account_balances: BTreeMap::new(),
+            addresses_derived: vec![],
+        }
+    }
+
+    fn transaction_detected(record: TransactionRecord) -> WalletEvent {
+        WalletEvent::TransactionDetected {
+            wallet_id: WALLET_ID,
+            record: Box::new(record),
+            balance: WalletCoreBalance::default(),
+            account_balances: BTreeMap::new(),
+            addresses_derived: vec![],
+        }
+    }
+
+    /// (1) A payment to a contact must persist as the outgoing,
+    /// negative row — not the contact chain's incoming, positive one.
+    ///
+    /// Before the fix both records reached `CoreChangeSet.records`;
+    /// because the persisted `transactions` row is keyed by txid alone,
+    /// the watch-only record (emitted last, since `all_accounts` visits
+    /// DashPay accounts after standard ones) defined the stored row and
+    /// a 0.69998912 payment *away* was persisted as `+69_998_912`.
+    #[tokio::test]
+    async fn contact_directed_payment_persists_as_outgoing_and_negative() {
+        let (tx, funding, watch_only) = contact_payment_records();
+        // Upstream ordering: standard account first, DashPay last.
+        let cs = build_core_changeset(&test_manager(), &block_processed(vec![funding, watch_only]))
+            .await;
+
+        assert_eq!(
+            cs.records.len(),
+            1,
+            "exactly one record may define the txid-keyed transaction row"
+        );
+        let persisted = &cs.records[0];
+        assert_eq!(persisted.txid, tx.txid());
+        assert_eq!(
+            persisted.direction,
+            TransactionDirection::Outgoing,
+            "a payment to a contact is money leaving this wallet"
+        );
+        assert_eq!(
+            persisted.net_amount,
+            CHANGE as i64 - FUNDING as i64,
+            "net must be -(spent - change), not the contact's credit"
+        );
+        assert!(
+            persisted.net_amount < 0,
+            "net_amount must be negative, was {}",
+            persisted.net_amount
+        );
+
+        // The coin that landed on the contact's chain is not ours, so it
+        // must never enter the wallet's TXO set — this is the phantom
+        // `isSpent = 0` row that only the contact's own spend could ever
+        // have cleared.
+        let utxo_outpoints: Vec<u32> = cs.new_utxos.iter().map(|u| u.outpoint.vout).collect();
+        assert_eq!(
+            utxo_outpoints,
+            vec![1],
+            "only our change output may become a wallet UTXO"
+        );
+        assert_eq!(cs.new_utxos[0].txout.value, CHANGE);
+    }
+
+    /// Same assertion for the first-sighting path, which delivers each
+    /// account's record as its own `TransactionDetected` event — there
+    /// is no sibling record in the batch to fall back on, so the filter
+    /// has to hold standalone.
+    #[tokio::test]
+    async fn contact_watch_only_detection_persists_no_transaction_row() {
+        let (_, _, watch_only) = contact_payment_records();
+        let cs = build_core_changeset(&test_manager(), &transaction_detected(watch_only)).await;
+
+        assert!(
+            cs.records.is_empty(),
+            "a contact's watch-only chain must not define a wallet transaction row"
+        );
+        assert!(
+            cs.new_utxos.is_empty(),
+            "the contact's output must not become a wallet UTXO"
+        );
+    }
+
+    /// The funding account's own `TransactionDetected` still persists
+    /// normally — the filter is scoped to the watch-only account, not
+    /// to the transaction.
+    #[tokio::test]
+    async fn funding_account_detection_of_the_same_payment_still_persists() {
+        let (tx, funding, _) = contact_payment_records();
+        let cs = build_core_changeset(&test_manager(), &transaction_detected(funding)).await;
+
+        assert_eq!(cs.records.len(), 1);
+        assert_eq!(cs.records[0].txid, tx.txid());
+        assert_eq!(cs.records[0].direction, TransactionDirection::Outgoing);
+        assert!(cs.records[0].net_amount < 0);
+    }
+
+    /// (2) A genuine receive is untouched: incoming, positive, and its
+    /// output still becomes a wallet UTXO.
+    #[tokio::test]
+    async fn genuine_receive_still_persists_incoming_and_positive() {
+        let tx = tx_with(&[(&our_receive_address(), PAID_TO_CONTACT)]);
+        let received = record(
+            &tx,
+            bip44_account_0(),
+            TransactionDirection::Incoming,
+            // Someone else's coins funded it.
+            Vec::new(),
+            vec![output(
+                0,
+                OutputRole::Received,
+                &our_receive_address(),
+                PAID_TO_CONTACT,
+            )],
+            PAID_TO_CONTACT as i64,
+        );
+        let cs = build_core_changeset(&test_manager(), &block_processed(vec![received])).await;
+
+        assert_eq!(cs.records.len(), 1);
+        assert_eq!(cs.records[0].direction, TransactionDirection::Incoming);
+        assert_eq!(cs.records[0].net_amount, PAID_TO_CONTACT as i64);
+        assert!(cs.records[0].net_amount > 0);
+        assert_eq!(cs.new_utxos.len(), 1, "a real receive still creates a TXO");
+        assert_eq!(cs.new_utxos[0].txout.value, PAID_TO_CONTACT);
+    }
+
+    /// (2b) A receive on a DashPay **receival** account — addresses
+    /// derived from *our* xpub, which a contact pays into — is money
+    /// genuinely arriving and must keep its incoming/positive row.
+    /// This is the boundary #926 drew and this change must not blur.
+    #[tokio::test]
+    async fn dashpay_receival_account_receive_is_unaffected() {
+        let tx = tx_with(&[(&our_receive_address(), PAID_TO_CONTACT)]);
+        let received = record(
+            &tx,
+            AccountType::DashpayReceivingFunds {
+                index: 0,
+                user_identity_id: [1u8; 32],
+                friend_identity_id: [2u8; 32],
+            },
+            TransactionDirection::Incoming,
+            Vec::new(),
+            vec![output(
+                0,
+                OutputRole::Received,
+                &our_receive_address(),
+                PAID_TO_CONTACT,
+            )],
+            PAID_TO_CONTACT as i64,
+        );
+        let cs = build_core_changeset(&test_manager(), &block_processed(vec![received])).await;
+
+        assert_eq!(
+            cs.records.len(),
+            1,
+            "receival accounts derive from OUR xpub — those funds are ours"
+        );
+        assert_eq!(cs.records[0].direction, TransactionDirection::Incoming);
+        assert_eq!(cs.records[0].net_amount, PAID_TO_CONTACT as i64);
+        assert_eq!(cs.new_utxos.len(), 1);
+    }
+
+    /// (3) An internal transfer — every output owned, none on a
+    /// contact's chain — is unaffected in direction, net and TXOs.
+    #[tokio::test]
+    async fn internal_transfer_is_unaffected() {
+        let tx = tx_with(&[
+            (&our_receive_address(), PAID_TO_CONTACT),
+            (&our_change_address(), CHANGE),
+        ]);
+        let internal = record(
+            &tx,
+            bip44_account_0(),
+            TransactionDirection::Internal,
+            vec![our_input()],
+            vec![
+                output(
+                    0,
+                    OutputRole::Received,
+                    &our_receive_address(),
+                    PAID_TO_CONTACT,
+                ),
+                output(1, OutputRole::Change, &our_change_address(), CHANGE),
+            ],
+            (PAID_TO_CONTACT + CHANGE) as i64 - FUNDING as i64,
+        );
+        let cs = build_core_changeset(&test_manager(), &block_processed(vec![internal])).await;
+
+        assert_eq!(cs.records.len(), 1);
+        assert_eq!(cs.records[0].direction, TransactionDirection::Internal);
+        assert_eq!(
+            cs.records[0].net_amount,
+            (PAID_TO_CONTACT + CHANGE) as i64 - FUNDING as i64
+        );
+        assert_eq!(
+            cs.new_utxos.len(),
+            2,
+            "both owned outputs stay in the wallet's TXO set"
+        );
+        assert_eq!(cs.spent_utxos.len(), 1, "the spent input is still removed");
+    }
+
+    /// Confirmation re-emits the same records under `updated`. The
+    /// filter has to hold there too, or the watch-only row would
+    /// re-clobber the correct one the moment the block landed.
+    #[tokio::test]
+    async fn confirmation_re_emit_does_not_reintroduce_the_watch_only_row() {
+        let (_, funding, watch_only) = contact_payment_records();
+        let event = WalletEvent::BlockProcessed {
+            wallet_id: WALLET_ID,
+            height: 1_001,
+            chain_lock: None,
+            inserted: vec![],
+            updated: vec![funding, watch_only],
+            matured: vec![],
+            balance: WalletCoreBalance::default(),
+            account_balances: BTreeMap::new(),
+            addresses_derived: vec![],
+        };
+        let cs = build_core_changeset(&test_manager(), &event).await;
+
+        assert_eq!(cs.records.len(), 1);
+        assert_eq!(cs.records[0].direction, TransactionDirection::Outgoing);
+    }
+
+    /// A contact spending an output that a *pre-fix* build already
+    /// persisted must still clear that stale row, so `derive_spent_utxos`
+    /// stays deliberately unfiltered. Only the transaction row and the
+    /// new-TXO projection are suppressed.
+    #[tokio::test]
+    async fn contact_spend_still_clears_a_stale_pre_fix_txo() {
+        let tx = tx_with(&[(&contact_address(), PAID_TO_CONTACT)]);
+        let watch_only_spend = record(
+            &tx,
+            contact_external_account(),
+            TransactionDirection::Outgoing,
+            vec![InputDetail {
+                index: 0,
+                value: PAID_TO_CONTACT,
+                address: contact_address(),
+            }],
+            vec![output(
+                0,
+                OutputRole::Sent,
+                &contact_address(),
+                PAID_TO_CONTACT,
+            )],
+            -(PAID_TO_CONTACT as i64),
+        );
+        let cs =
+            build_core_changeset(&test_manager(), &block_processed(vec![watch_only_spend])).await;
+
+        assert!(
+            cs.records.is_empty(),
+            "the contact spending their own coin is not a transaction of ours"
+        );
+        assert_eq!(
+            cs.spent_utxos.len(),
+            1,
+            "the stale pre-fix TXO must still be removed"
+        );
+        assert_eq!(cs.spent_utxos[0].outpoint, funding_outpoint());
     }
 }
 

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -1003,11 +1003,14 @@ async fn is_chain_locked(
 /// the derived-address rows, and `derive_spent_utxos` (so a contact
 /// spending an output persisted *before* this fix still clears the
 /// stale row).
+///
+/// The predicate itself is canonical upstream
+/// ([`AccountType::is_contact_owned`], dashpay/rust-dashcore#952): its
+/// exhaustive match forces any future account type to declare whether
+/// its coins are the wallet's or a contact's, so this seam and #926's
+/// cannot drift apart.
 fn is_contact_watch_only(record: &TransactionRecord) -> bool {
-    matches!(
-        record.account_type,
-        AccountType::DashpayExternalAccount { .. }
-    )
+    record.account_type.is_contact_owned()
 }
 
 /// Derive the "ours" UTXOs created by a transaction's outputs.


### PR DESCRIPTION
Supersedes #4353 — same change, recreated on a `dashpay/platform` branch per repo policy (no more personal-fork PRs). Commits and authorship unchanged; full review history on #4353.

## Context: this completes dashpay/rust-dashcore#926

[dashpay/rust-dashcore#926](https://github.com/dashpay/rust-dashcore/pull/926) (@romchornyi, merged 2026-08-07) established the policy:

> A DashPay **external** account is watch-only by construction ... Its addresses derive from a *contact's* xpub, so this wallet can observe those outputs but can never sign for them. **They are the contact's coins; this wallet only ever pays into them.**

and applied it by dropping `dashpay_external_accounts` from `ManagedAccountCollection::all_funding_accounts` / `_mut`, which covers `balance`, `account_balances`, `utxos` and `get_spendable_utxos` in one place. `dashpay_receival_accounts` were deliberately kept — those derive from *our* xpub, so a contact paying into them really is money arriving.

That fixed the balance layer. **The persist-time projection is the same rule's second home, and it was missed.** This PR applies the identical policy there. The `key-wallet` pin on `v4.2-dev` (`b056d07c`) already contains #926, so the two layers currently disagree with each other: the in-memory balance excludes the contact's coins, the persisted store still counts them.

## The defect

Upstream `check_core_transaction` emits **one `TransactionRecord` per matched account** (`key_wallet::transaction_checking::wallet_checker`). A payment to a contact matches two accounts, producing two records that share one txid:

| record's account | `direction` | `net_amount` |
|---|---|---|
| funding (BIP44/BIP32/CoinJoin) | `Outgoing` | `change - spent` |
| `DashpayExternalAccount` | `Incoming` | `+paid` |

The external account's record is not *wrong about its own account* — that chain did receive an output. It is wrong as a description of the **wallet**.

`build_core_changeset` projected **both** records into `CoreChangeSet.records`, and `derive_new_utxos` turned the contact's output into a wallet UTXO. The persisted `transactions` row is keyed by **txid alone** — there is no per-account dimension to disambiguate it, because `transaction_account_involvements` is only written for provider-key accounts (see follow-ups below). So whichever record is stored last defines the row, and the watch-only one is emitted last, since `all_accounts` visits the DashPay accounts after the standard ones.

Field-observed on a testnet device store (2026-08-09): **every** payment to a contact is persisted with `direction=incoming` and a positive `net_amount` — a 0.69998912 DASH payment *away* stored as `+69998912` where the wallet's true net is `-70000000`. The paid output sits in `txos` with `isSpent=0` indefinitely (only the contact's own spend could ever flip it), so any SQL-sum consumer reads a phantom balance. A tester's mainnet wallet shows the same signature ("+3.83 change instead of −0.1 payment").

## What changed

`packages/rs-platform-wallet/src/changeset/core_bridge.rs` — one predicate plus the two projection sites that consume it:

- **`is_contact_watch_only(record)`** — matches `AccountType::DashpayExternalAccount { .. }`, carrying the rationale and the #926 link so the line does not get "fixed" back.
- **`derive_new_utxos`** returns nothing for such a record. Direct counterpart of #926 dropping those accounts from `utxos()` / `get_spendable_utxos()`.
- **`build_core_changeset`** omits them from `CoreChangeSet.records` on both paths: the per-record `TransactionDetected` first sighting, and the `inserted`/`updated`/`matured` lists of `BlockProcessed`. The confirmation path matters on its own — re-emitting the watch-only record when the block lands would re-clobber the row exactly as the first sighting did.

The funding account's record — already `Outgoing` with `net = -(spent - change)`, exactly what `balance()` semantics imply — becomes the row that lands. No FFI or storage-schema change; `CoreChangeSet` and every persistence signature are untouched.

### What deliberately did not change

Everything from the same event that is genuinely ours to remember is preserved, so the event is never dropped wholesale:

- **`addresses_marked_used` and `account_highest_used`** — the contact's address pool must keep advancing or the wallet would pay the same contact address twice. `is_empty_no_records()` counts these, so a watch-only-only event still round-trips to the persister.
- **`addresses_derived`** — gap-limit extensions on the contact's chain still persist.
- **`derive_spent_utxos` stays unfiltered** — so a contact spending an output that a *pre-fix* build already persisted still clears that stale row. Covered by a test.
- **Detection, monitoring and filter membership** are untouched, exactly as in #926: the address set is built from `all_accounts`.

One intended behavioural consequence: a third party paying our contact (which we see, because we monitor that chain) no longer produces a wallet `transactions` row or TXO. Under #926's policy that is correct — those were never our coins — and it removes a second, quieter source of the same phantom balance.

## Required for correct Android behavior

The Android wallet currently compensates for these records **at read time**. That correction is a workaround for wrong data on disk, not a fix: every other consumer of the same store reads the rows raw — iOS parity, and any future feature that trusts `direction` / `net_amount` / `txos` — and each would have to reinvent the same compensation. Fixing it at the point of persistence lets the Android read-time correction be retired.

## Testing

`cargo test -p platform-wallet --lib` — **618 passed, 0 failed.** No existing test encoded the old projection.
`cargo test -p platform-wallet-ffi --lib` — 261 passed, 0 failed.
`cargo clippy -p platform-wallet --all-targets -- -D warnings` and `cargo fmt --check` clean.

Eight new tests in `contact_watch_only_projection_tests`, built from the record pair a real contact payment produces:

1. `contact_directed_payment_persists_as_outgoing_and_negative` — both records in one `BlockProcessed`; asserts exactly one record reaches the persister, `Outgoing`, `net == -70_000_000`, and that only the change output becomes a TXO.
2. `contact_watch_only_detection_persists_no_transaction_row` — the standalone `TransactionDetected` path, where there is no sibling record in the batch to fall back on.
3. `funding_account_detection_of_the_same_payment_still_persists` — the filter is scoped to the account, not the transaction.
4. `genuine_receive_still_persists_incoming_and_positive` — unchanged: incoming, positive, TXO created.
5. `dashpay_receival_account_receive_is_unaffected` — the boundary #926 drew; receival accounts derive from *our* xpub and must keep their incoming/positive row.
6. `internal_transfer_is_unaffected` — all outputs owned, none type-13: direction, net, both TXOs and the spent input all unchanged.
7. `confirmation_re_emit_does_not_reintroduce_the_watch_only_row` — the `updated` list.
8. `contact_spend_still_clears_a_stale_pre_fix_txo` — no transaction row, but the spent-TXO removal still fires.

The four fix-dependent tests (1, 2, 7, 8) were **verified to fail without the change** — reverting `is_contact_watch_only` to `false` reproduces the exact defect (`records.len()` is 2 where 1 is allowed). Tests 3–6 are guards and pass either way by design.

## Notes / not in scope

Three adjacent items surfaced while tracing this, deliberately left for follow-up:

1. **Historical rows stay wrong.** Rows persisted before this fix keep their bad `direction` / `net_amount`, and their phantom `txos` rows persist until the contact spends. Android's read-time correction covers its own surface; a one-time store-rewrite pass would be the general fix and is intentionally out of scope here.
2. **`transaction_account_involvements` is effectively unpopulated.** It is written only when the account is a provider-key account *and* the transaction is a provider special tx (`PlatformWalletPersistenceHandler`), so ordinary payments never get a row — which is precisely why the txid-keyed `transactions` row has no per-account dimension and this collision was possible at all. Populating it generally would give per-account history a real join (the `INNER JOIN transaction_account_involvements` query in `TransactionDao` returns nothing for normal accounts today).
3. **`txos.isInstantLocked` has no consumer.** It is written from the TXO's first sighting and restored on load, but nothing reads it to make a decision — and because `TransactionInstantLocked` carries no UTXO re-emit, a TXO first seen in mempool never has the flag flipped when its IS lock later arrives. Worth either wiring up or removing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contact watch-only transactions so they no longer appear as regular persisted transactions or newly derived spendable outputs.
  * Continued tracking address usage, derived addresses, and cleanup of spent outputs.
  * Corrected processing across outgoing contact payments, confirmations, genuine incoming payments, internal transfers, and stale output removal.
* **Maintenance**
  * Updated the underlying wallet engine revision for improved compatibility and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->