### PR TITLE
fix(swift-sdk): gate the ordered bring-up on the seed actually owning the wallet

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -671,17 +671,10 @@ public class PlatformWalletManager: ObservableObject {
     /// through the Keychain-backed resolver per-operation. This unlock does
     /// two things, both through a resolver (the seed never becomes resident):
     ///
-    /// 1. **Verify** the resolved seed binds to this wallet —
-    ///    `platform_wallet_verify_seed_binds_to_wallet_cached` derives the
-    ///    BIP44 account-0 xpub through the resolver and compares it to the
-    ///    persisted one. A mis-mapped Keychain slot derives a different xpub
-    ///    and the call throws, so a wrong seed never signs for this wallet.
-    ///    The outcome is launch-invariant while the mnemonic Keychain item
-    ///    is untouched, so the first success persists a marker (the xpub
-    ///    bound to the item's identity stamp) on the wallet row and later
-    ///    launches skip the resolver. Rust re-runs the full check when the
-    ///    marker no longer matches — wallet re-import, or any rewrite of
-    ///    the mnemonic Keychain item (which changes the stamp).
+    /// 1. **Verify** the resolved seed binds to this wallet — delegated in
+    ///    full to [`verifySeedBinding`](Self/verifySeedBinding(_:)), which is
+    ///    also the entry point for callers that need the gate WITHOUT the
+    ///    drain below.
     /// 2. **Drain** (in the background) any contact-crypto deferred while
     ///    the wallet was seedless — `platform_wallet_drain_pending_contact_crypto`.
     ///    The drain re-fetches + decrypts over the network, so it runs in a
@@ -701,8 +694,46 @@ public class PlatformWalletManager: ObservableObject {
     ///   throwing.
     /// - Throws: `PlatformWalletError` if the verify FFI fails (e.g. the
     ///   resolved seed does not bind — a mis-mapped Keychain slot).
+    /// Whether a wallet has a Keychain seed at all, once the binding holds.
+    public enum SeedBindingCheck: Sendable, Equatable {
+        /// A mnemonic is stored for this wallet and it derives the wallet's
+        /// persisted BIP44 account-0 xpub. Signing for this wallet is sound.
+        case verified
+        /// No mnemonic is stored — a genuine watch-only wallet, imported by
+        /// xpub. Nothing to contradict and nothing that can sign.
+        case watchOnly
+    }
+
+    /// Verify that the Keychain seed for `wallet` actually owns it — and do
+    /// nothing else.
+    ///
+    /// This is step 1 of [`unlockWalletFromKeychain`](Self/unlockWalletFromKeychain(_:))
+    /// on its own. It exists because that method is not a verification
+    /// primitive: it also schedules a background drain of the deferred
+    /// contact crypto. A caller that needs the gate and not the drain — one
+    /// about to run its own mnemonic-derived work, such as
+    /// [`startWalletSubsystems`](Self/startWalletSubsystems(wallet:budget:gapLimit:storage:))
+    /// — would otherwise have to launch a competing drain to ask the
+    /// question. Two drains over two snapshots duplicate the network and
+    /// ECDH work and race each other's channel-broken and auto-accept
+    /// writes, which is why the unlock path already refuses to stack them.
+    ///
+    /// Marker-cached exactly as the unlock is: the outcome is a pure function
+    /// of (mnemonic, network) against a fixed persisted xpub, so a match
+    /// costs a string comparison and never touches the Keychain. A rewritten
+    /// mnemonic item changes its stamp and forces the full check again.
+    ///
+    /// Publishes `dashPayUnlockStatus[walletId].seedMismatch` from the
+    /// result, so a caller may read it afterwards — but callers that must not
+    /// race the publisher should use the return value, which is ordered with
+    /// respect to the work it guards.
+    ///
+    /// - Returns: `.verified` when the stored seed binds, `.watchOnly` when
+    ///   there is no stored mnemonic to bind.
+    /// - Throws: `PlatformWalletError` when the seed does not bind (a
+    ///   mis-mapped Keychain slot) or the verify FFI otherwise fails.
     @discardableResult
-    public func unlockWalletFromKeychain(_ wallet: ManagedPlatformWallet) throws -> Bool {
+    public func verifySeedBinding(_ wallet: ManagedPlatformWallet) throws -> SeedBindingCheck {
         try ensureConfigured()
         let walletId = wallet.walletId
         guard walletId.count == 32 else {
@@ -716,7 +747,7 @@ public class PlatformWalletManager: ObservableObject {
         // check; the plaintext is never materialized in Swift.
         let walletStorage = WalletStorage()
         guard walletStorage.hasMnemonic(for: walletId) else {
-            return false
+            return .watchOnly
         }
 
         let walletHandle = wallet.handle
@@ -807,6 +838,21 @@ public class PlatformWalletManager: ObservableObject {
             }
             throw error
         }
+
+        return .verified
+    }
+
+    @discardableResult
+    public func unlockWalletFromKeychain(_ wallet: ManagedPlatformWallet) throws -> Bool {
+        // Step 1 in full, side-effect-free. A watch-only wallet has nothing
+        // to unlock and nothing to drain for.
+        guard try verifySeedBinding(wallet) == .verified else { return false }
+
+        let walletId = wallet.walletId
+        let walletHandle = wallet.handle
+        // Resolver-backed signer for the drain: the mnemonic is fetched from
+        // the Keychain inside the resolver vtable Rust-side; no resident seed.
+        let coreSigner = MnemonicResolver()
 
         // Heal pre-breadcrumb identity keys so they sign via the resolver
         // (derive-sign-destroy) rather than the stored scalar. Idempotent and

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -734,6 +734,22 @@ public class PlatformWalletManager: ObservableObject {
     ///   mis-mapped Keychain slot) or the verify FFI otherwise fails.
     @discardableResult
     public func verifySeedBinding(_ wallet: ManagedPlatformWallet) throws -> SeedBindingCheck {
+        try verifySeedBinding(wallet, storage: WalletStorage())
+    }
+
+    /// [`verifySeedBinding`](Self/verifySeedBinding(_:)) against a specific
+    /// `WalletStorage`.
+    ///
+    /// A caller that resolves the mnemonic from one store must be verified
+    /// against that same store, or the check answers a question about a
+    /// different Keychain than the one the work will read — approving one
+    /// mnemonic while the derivation uses another. `startWalletSubsystems`
+    /// takes a `storage` parameter for exactly this reason and passes it here.
+    @discardableResult
+    func verifySeedBinding(
+        _ wallet: ManagedPlatformWallet,
+        storage walletStorage: WalletStorage
+    ) throws -> SeedBindingCheck {
         try ensureConfigured()
         let walletId = wallet.walletId
         guard walletId.count == 32 else {
@@ -745,15 +761,19 @@ public class PlatformWalletManager: ObservableObject {
         // A genuine watch-only wallet (imported by xpub, never holding a
         // seed) has no Keychain mnemonic — stays watch-only. Existence-only
         // check; the plaintext is never materialized in Swift.
-        let walletStorage = WalletStorage()
         guard walletStorage.hasMnemonic(for: walletId) else {
+            // No mnemonic is no longer a mismatch: a wallet whose seed failed
+            // to bind and whose Keychain item was then removed must not keep
+            // publishing the banner for a seed that is no longer there.
+            setDashPaySeedMismatch(walletId, false)
             return .watchOnly
         }
 
         let walletHandle = wallet.handle
-        // Resolver-backed signer: the mnemonic is fetched from the Keychain
-        // inside the resolver vtable Rust-side; no resident seed.
-        let coreSigner = MnemonicResolver()
+        // Resolver-backed signer, over the SAME store the check above read and
+        // the caller's work will read: the mnemonic is fetched from the
+        // Keychain inside the resolver vtable Rust-side; no resident seed.
+        let coreSigner = MnemonicResolver(storage: walletStorage)
 
         // Wrong-seed / wrong-wallet gate, marker-cached: the check is a pure
         // function of (mnemonic, network) against the wallet's persisted

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerStartup.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerStartup.swift
@@ -141,7 +141,11 @@ extension PlatformWalletManager {
         // hosts commonly kick the unlock off asynchronously, so the flag
         // races this call. The verify is marker-cached, so the common path
         // costs a string comparison.
-        try verifySeedBinding(wallet)
+        //
+        // Against `storage`, not a default one: the resolver below reads that
+        // store, and verifying a different Keychain than the work will use
+        // would approve one mnemonic while another derives the accounts.
+        try verifySeedBinding(wallet, storage: storage)
 
         let handle = self.handle
         // Only a definitive "no such item" means watch-only. A lookup that

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerStartup.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerStartup.swift
@@ -97,8 +97,11 @@ extension PlatformWalletManager {
     ///
     /// - Throws: only for a malformed request — an unconfigured manager, a
     ///   malformed wallet id, an unknown wallet, or a `budget` outside the
-    ///   supported range. An unreachable Platform, a failed sync pass and an
-    ///   unfinished drain are all reported through the returned status.
+    ///   supported range — or when the stored seed does not bind to this
+    ///   wallet, which is a malformed pairing of the two and the one condition
+    ///   under which none of this may run at all. An unreachable Platform, a
+    ///   failed sync pass and an unfinished drain are all reported through the
+    ///   returned status instead, because Core sync must start regardless.
     ///
     /// # Key material
     ///
@@ -122,6 +125,23 @@ extension PlatformWalletManager {
                 "walletId must be 32 bytes, got \(walletId.count)"
             )
         }
+
+        // Nothing below may run on a seed that does not own this wallet.
+        // Everything this call does with key material is unauthenticated —
+        // the resolver derives whatever the Keychain holds, and
+        // `register_contact_account` keys its existence check on the contact
+        // pair rather than the xpub, so a wrong receiving xpub is written
+        // once and no later correct-seed pass revisits it. The wallet then
+        // watches addresses nobody pays to, with no symptom but payments that
+        // never arrive.
+        //
+        // Enforced here rather than left to the host: a client that has to
+        // remember to gate this call is a client that will eventually forget,
+        // and the published `seedMismatch` flag cannot be that gate anyway —
+        // hosts commonly kick the unlock off asynchronously, so the flag
+        // races this call. The verify is marker-cached, so the common path
+        // costs a string comparison.
+        try verifySeedBinding(wallet)
 
         let handle = self.handle
         // Only a definitive "no such item" means watch-only. A lookup that


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`startWalletSubsystems` (#4359) builds its own `MnemonicResolver` and `KeychainSigner`, and did no binding check — so it never inherited the wrong-seed gate `unlockWalletFromKeychain` applies. On a wallet whose identity is already known it skips discovery and goes straight to the contact sync and drain, deriving DIP-15 contact accounts from a mnemonic the wallet has already rejected.

**That damage does not heal.** `register_contact_account` keys its existence check on `(index, owner, friend)` and never on the xpub, and unlike the external-account side there is no rotation sweep for receiving accounts. A wrong xpub is written once and every later correct-seed pass no-ops over it, so the wallet watches addresses nobody pays to — with no symptom except payments that never arrive.

The other two drain branches are narrower, and worth stating so the fix is not over-scoped:

- `RegisterExternal` is self-defending — a wrong-seed ECDH product fails the 69/78/107-byte xpub format parse, the channel is marked broken, and the existing rotation sweep rebuilds it once the correct seed is present.
- The auto-accept leg cannot broadcast at all: `KeychainSigner` passes the on-chain public key as a binding and the signer rejects a wrong-seed key before producing a signature.

So nothing reaches Platform under a mismatched seed. What breaks is local state, silently and permanently.

Reported by review on dashpay/dashwallet-ios#961, which is the first client of this call and is blocked on this.

## What was done?
<!--- Describe your changes in detail -->

**`PlatformWalletManager.verifySeedBinding(_:)`** — step 1 of `unlockWalletFromKeychain`, extracted verbatim and made public. Returns `.verified` / `.watchOnly`, throws on a mismatch. `unlockWalletFromKeychain` is now that call plus its drain, so no existing caller changes behaviour.

**`startWalletSubsystems` calls it before anything else**, so every client is protected rather than every client having to remember.

### Why a new API rather than calling the unlock

`unlockWalletFromKeychain` is not a verification primitive. When the queue is non-empty it also starts a detached drain and sets the Swift-side `draining` guard. Using it as a preflight would leave this call racing a second drain over a second snapshot — duplicated network and ECDH work, and competing channel-broken / auto-accept writes. That is precisely what the existing guard exists to prevent, and it is reachable both from a persisted pending queue and from work the inline contact sync queues while the startup drain runs.

### Why in the SDK rather than in each host

Two reasons, and the second is the load-bearing one:

1. A host that has to remember to gate this call is a host that will eventually forget.
2. **The published `seedMismatch` flag cannot serve as that gate.** Hosts commonly kick the unlock off asynchronously — iOS schedules it in a detached, un-awaited `Task` and returns the wallet immediately, then goes straight into the bring-up — so the flag is racing the very call it is meant to guard, and on the launch where the seed is wrong it may not be set yet. A verification performed inside the call is ordered with respect to the work it protects; a flag read outside it is not.

Cost on the common path is a string comparison: the verify is marker-cached, and a match never touches the Keychain.

### Considered and rejected

Putting the gate in `rs-platform-wallet`'s `start_wallet_subsystems` instead. That is the stronger home — a future JNI client inherits it — but the marker/stamp cache that keeps the check free is persisted host-side, so Rust would need both threaded through the FFI plus a new terminal `SeedMismatch` status, i.e. an ABI addition. Worth doing when a second client appears; not worth blocking a security fix behind today.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
xcodebuild -scheme SwiftDashSDK -sdk iphonesimulator   # clean
```

Plus a clean `dashpay` build of dashwallet-ios#961 against this branch, on the iOS 26.5 simulator — that PR drops its own app-side workaround in favour of this gate.

**Not covered:** no automated test. Exercising it needs a wallet whose persisted account-0 xpub disagrees with the Keychain mnemonic, which the SwiftDashSDK test targets have no fixture for today; the underlying verification itself is already covered Rust-side in `seed_binding.rs` (`verify_seed_binds_rejects_wrong_signer`).

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None to existing callers — `unlockWalletFromKeychain` keeps its signature and behaviour.

One new failure mode for adopters of `startWalletSubsystems`: it now throws when the stored seed does not bind to the wallet, where it previously proceeded. That is the point of the change, and the documented contract already says Core sync must start regardless — the iOS call site catches, logs, and starts SPV.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added seed-to-wallet binding verification before unlocking or starting wallet services.
  * Prevented wallet startup when stored key material does not match the selected wallet.
  * Improved watch-only wallet handling without attempting identity-key setup.

* **Bug Fixes**
  * Deferred contact encryption processing now occurs only after successful wallet verification.
  * Unlock operations correctly report unsuccessful results for watch-only wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->