### PR TITLE
fix(platform-wallet): gate candidate-address re-export behind shielded feature

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/mod.rs
@@ -45,6 +45,7 @@ where
 pub use provider::{
     PerAccountPlatformAddressState, PerWalletPlatformAddressState, PlatformAddressTag,
 };
+#[cfg(feature = "shielded")]
 pub(crate) use wallet::merge_platform_payment_candidate_addresses;
 pub use wallet::PlatformAddressWallet;
 pub use withdrawal::WithdrawalPlan;


### PR DESCRIPTION
## Issue being fixed or feature implemented

Building `platform-wallet` without the `shielded` feature emits an unused-import warning: the `pub(crate)` re-export of `merge_platform_payment_candidate_addresses` in `platform_addresses/mod.rs` is unconditional, but its only external consumer (`platform_wallet.rs`) imports it under `#[cfg(feature = "shielded")]`.

## What was done?

Added `#[cfg(feature = "shielded")]` to the re-export in `packages/rs-platform-wallet/src/wallet/platform_addresses/mod.rs`. The helper is still used inside `wallet.rs` itself without the gate (via the module path, not this re-export), so only the re-export needed gating.

## How Has This Been Tested?

- `cargo clippy -p platform-wallet --all-targets` — clean, the unused-import warning is gone
- `cargo clippy -p platform-wallet --all-features --tests` — still clean
- `cargo test -p platform-wallet --lib` — 652 passed, 0 failed

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)