### PR TITLE
fix(platform-wallet): fold fetched on-chain state into already-known identities on load

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/identity/network/loading.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/loading.rs
@@ -253,6 +253,15 @@ impl IdentityWallet {
             }
 
             if let Some(managed) = info.identity_manager.managed_identity_mut(&identity_id) {
+                // Fold the freshly fetched on-chain state into an
+                // already-known identity too — the add above only runs for
+                // new ones, and without this a re-load kept serving the
+                // stale key set (keys added from another device never
+                // appeared, and contact requests referencing them failed
+                // key-index validation). Same replace `refresh_identity`
+                // does; the `set_status` below persists the full snapshot
+                // changeset, so the updated keys reach the store.
+                managed.identity = identity.clone();
                 managed.set_status(IdentityStatus::Active, &self.persister);
                 managed.wallet_id = Some(wallet_id);
                 // Breadcrumbs for every re-derivable key (was MASTER-only). A


### PR DESCRIPTION
## Problem

`load_identity_by_index` only folds the freshly fetched identity into the `IdentityManager` when the identity is **not already known**. For a known identity the fetched state is discarded — only status, key breadcrumbs, and DPNS names update — so a re-load keeps serving the stale key set.

Real-world impact (observed on a mainnet identity whose DIP-15 ENCRYPTION/DECRYPTION pair was added from another device): the local store never learns keys 4/5, the wallet's key views show 4 keys forever, and incoming contact requests referencing the new keys fail key-index validation (`Recipient key index 5 not found on identity …`), marking the contact channels broken.

## Fix

Replace `managed.identity` with the fetched identity before the existing `set_status` call — the same fold `refresh_identity` performs. `set_status` already persists the full snapshot changeset, so the refreshed key set reaches the store with no new persistence machinery.

## Verification

- `cargo check` / `cargo fmt --check` / `clippy` clean (one pre-existing unused-import warning elsewhere in the crate, untouched).
- End-to-end on a real device: iOS wallet whose identity showed 4 persisted keys against 6 on mainnet Platform; after this fix an in-app reload persists all 6 (the DIP-15 pair appears, contract-bounds intact).

Related follow-up (not in this PR): the same identity row was persisted with `is_local == false` despite belonging to the wallet — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)