### PR TITLE
chore(release): update changelog and bump version to 4.2.0-dev.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,126 @@
+## [4.2.0-dev.1](https://github.com/dashpay/platform/compare/v4.1.0...v4.2.0-dev.1) (2026-08-12)
+
+
+### ⚠ BREAKING CHANGES
+
+* **drive-abci:** cross-check the contested index of a prefunded voting balance at protocol v14 (#4281)
+* **kotlin-sdk:** keystore rework — policy-alias split, layered key recovery, durable repair, structured signer errors (stacked on #4191) (#4183)
+* **drive:** make shared-prefix aggregate indexes insertable at protocol v14 (#4265)
+* **dashmate:** record whether a platform image was chosen instead of deriving it (#4239)
+
+### Features
+
+* **dashmate:** record whether a platform image was chosen instead of deriving it ([#4239](https://github.com/dashpay/platform/issues/4239))
+* expose Platform-to-Shielded capacity preflight ([#4360](https://github.com/dashpay/platform/issues/4360))
+* **kotlin-sdk:** bind OP_RETURN, output-order and VIN0-change builder controls ([#4288](https://github.com/dashpay/platform/issues/4288))
+* **kotlin-sdk:** dashpay invitations — create, claim, reclaim, persistence (DIP-13) ([#4284](https://github.com/dashpay/platform/issues/4284))
+* **kotlin-sdk:** expose core_wallet_next_receive_address / next_change_address (Swift parity) ([#4260](https://github.com/dashpay/platform/issues/4260))
+* **kotlin-sdk:** keystore rework — policy-alias split, layered key recovery, durable repair, structured signer errors (stacked on [#4191](https://github.com/dashpay/platform/issues/4191)) ([#4183](https://github.com/dashpay/platform/issues/4183))
+* **kotlin-sdk:** split build/broadcast with reservation release for BIP70-style deferred submission ([#4308](https://github.com/dashpay/platform/issues/4308))
+* **kotlin-sdk:** tx-label & asset-lock-kind DAO resolver queries ([#4251](https://github.com/dashpay/platform/issues/4251))
+* **platform-wallet:** add encrypted txMetadata document support ([#4277](https://github.com/dashpay/platform/issues/4277))
+* **platform-wallet:** classic Dash message signing (signMessage) over FFI, JNI, Kotlin, and Swift, closes [#4259](https://github.com/dashpay/platform/issues/4259) [#4279](https://github.com/dashpay/platform/issues/4279)
+* **platform-wallet:** CoinJoin-drain asset-lock funding for the shielded pool ([#4327](https://github.com/dashpay/platform/issues/4327))
+* **platform-wallet:** derive owner/voting provider keys Rust-side ([#4338](https://github.com/dashpay/platform/issues/4338))
+* **platform-wallet:** expose an invitation's prospective identity id ([#4332](https://github.com/dashpay/platform/issues/4332))
+* **platform-wallet:** own the DashPay startup ordering instead of each client ([#4359](https://github.com/dashpay/platform/issues/4359))
+* **platform-wallet:** persist DashPay payment history through the persister callback ([#4326](https://github.com/dashpay/platform/issues/4326))
+* **platform-wallet:** pool BIP44 + BIP32 + DashPay receiving funds on the asset-lock path ([#4350](https://github.com/dashpay/platform/issues/4350))
+* **platform-wallet:** pool BIP44 + BIP32 + DashPay receiving funds on the send path ([#4329](https://github.com/dashpay/platform/issues/4329))
+* **platform-wallet:** rebuild tracked asset locks after restore; honest scan-derived shielded history ([#4342](https://github.com/dashpay/platform/issues/4342))
+* **platform-wallet:** reconstruct sent DashPay payments from tx history ([#4300](https://github.com/dashpay/platform/issues/4300))
+* **platform-wallet:** registry-owned coordinator lifecycle with Rust-owned FFI callback contexts ([#4268](https://github.com/dashpay/platform/issues/4268))
+* **platform-wallet:** wallet-level DPNS username marketplace with FFI and Swift wrappers ([#4348](https://github.com/dashpay/platform/issues/4348))
+* **platform:** introduce protocol version 14 ([#4267](https://github.com/dashpay/platform/issues/4267))
+* ranked aggregate indexes with provable top-K queries (protocol v14) ([#4266](https://github.com/dashpay/platform/issues/4266))
+* **rs-sdk:** own the masternode voting-key facts ([#4340](https://github.com/dashpay/platform/issues/4340))
+* **sdk:** add transport feature to dapi-grpc for types-only consumers ([#4344](https://github.com/dashpay/platform/issues/4344))
+* **sdk:** expose OP_RETURN, output-order and change-to-VIN0 controls ([#4286](https://github.com/dashpay/platform/issues/4286))
+* **sdk:** expose the label each contender actually requested ([#4331](https://github.com/dashpay/platform/issues/4331))
+* **sdk:** masternodes-by-voting-key lookup (contested-username voting post-cutover) ([#4258](https://github.com/dashpay/platform/issues/4258))
+* **swift-sdk:** expose watermark-freeze sync fault flag (syncFaultDetected) ([#4320](https://github.com/dashpay/platform/issues/4320))
+* **swift-sdk:** split build/broadcast with reservation release for BIP70-style deferred submission ([#4322](https://github.com/dashpay/platform/issues/4322))
+* **swift-sdk:** typed DPNS contested-name browsing for voters ([#4328](https://github.com/dashpay/platform/issues/4328))
+
+
+### Bug Fixes
+
+* **dashmate:** extend Core shutdown grace period ([#4307](https://github.com/dashpay/platform/issues/4307))
+* **docs:** point parity manifest at the renamed identity-resume test, closes [#4015](https://github.com/dashpay/platform/issues/4015)
+* **dpp:** derive deterministic names for unnamed document type indexes ([#4280](https://github.com/dashpay/platform/issues/4280))
+* **dpp:** make document type index update validation name-order independent ([#4291](https://github.com/dashpay/platform/issues/4291))
+* **dpp:** stop hard-erroring on index-order-only contract updates ([#4295](https://github.com/dashpay/platform/issues/4295))
+* **drive-abci:** cross-check the contested index of a prefunded voting balance at protocol v14 ([#4281](https://github.com/dashpay/platform/issues/4281))
+* **drive:** derive wasm-drive-verify platform version cap from rs-platform-version ([#4269](https://github.com/dashpay/platform/issues/4269))
+* **drive:** make shared-prefix aggregate indexes insertable at protocol v14 ([#4265](https://github.com/dashpay/platform/issues/4265))
+* **kotlin-sdk:** unmanaged-identity reads return absence + typed SigningKeyUnavailable (split from [#4183](https://github.com/dashpay/platform/issues/4183)) ([#4191](https://github.com/dashpay/platform/issues/4191))
+* **platform-wallet:** accept legacy dashj key purposes on inbound contact requests ([#4372](https://github.com/dashpay/platform/issues/4372))
+* **platform-wallet:** batch wallet-event persistence + expose sync_fault (watermark-freeze mitigations) ([#4314](https://github.com/dashpay/platform/issues/4314))
+* **platform-wallet:** finalize reconstructed asset locks as RecoveredFromChain, in-session ([#4347](https://github.com/dashpay/platform/issues/4347))
+* **platform-wallet:** fold fetched on-chain state into already-known identities on load ([#4374](https://github.com/dashpay/platform/issues/4374))
+* **platform-wallet:** gate candidate-address re-export behind shielded feature ([#4369](https://github.com/dashpay/platform/issues/4369))
+* **platform-wallet:** lossless mpsc persistence drain — root-cause fix for the sync-watermark freeze ([#4315](https://github.com/dashpay/platform/issues/4315))
+* **platform-wallet:** preserve reported-consumed asset-lock recovery ([#4357](https://github.com/dashpay/platform/issues/4357))
+* **platform-wallet:** raise the invitation cap to cover the contested username tier ([#4362](https://github.com/dashpay/platform/issues/4362))
+* **platform-wallet:** reject trailing bytes in persisted asset-lock proof blobs ([#4346](https://github.com/dashpay/platform/issues/4346))
+* **platform-wallet:** report an unanswered identity scan as incomplete, not empty ([#4352](https://github.com/dashpay/platform/issues/4352))
+* **platform-wallet:** stale-islock to chainlock fallback for the L1 invite claim ([#4364](https://github.com/dashpay/platform/issues/4364))
+* **platform-wallet:** stop a contact's watch-only chain from defining the persisted transaction row ([#4363](https://github.com/dashpay/platform/issues/4363))
+* **platform-wallet:** survive an ambiguous re-broadcast when resuming a Built asset lock ([#4367](https://github.com/dashpay/platform/issues/4367))
+* **platform-wallet:** type signer-reported missing key as MessageSigningKeyUnavailable ([#4321](https://github.com/dashpay/platform/issues/4321))
+* **release:** base changelog on the immediately-preceding release ([#4229](https://github.com/dashpay/platform/issues/4229))
+* **rs-sdk-ffi:** build the voter identifier from ProTxHash byte order ([#4333](https://github.com/dashpay/platform/issues/4333))
+* **sdk:** poll message signing on the big-stack worker, and throw on JNI string-allocation failure
+* **sdk:** restore proved current-epoch fetch with two-step explicit-start query ([#4231](https://github.com/dashpay/platform/issues/4231))
+* **swift-example-app:** gate identity resumes by funding type ([#4015](https://github.com/dashpay/platform/issues/4015))
+* **swift-sdk:** gate the ordered bring-up on the seed actually owning the wallet ([#4368](https://github.com/dashpay/platform/issues/4368))
+* **swift-sdk:** isLocal = mine-or-tracked; promote wallet identities, fix observed-entry mislinking ([#4375](https://github.com/dashpay/platform/issues/4375))
+* **test-suite:** stabilize platform e2e tests ([#4214](https://github.com/dashpay/platform/issues/4214))
+
+
+### Performance Improvements
+
+* **platform-wallet:** keep the contact fetch off the drain's repeating-rejection path ([#4373](https://github.com/dashpay/platform/issues/4373))
+
+
+### Documentation
+
+* **agents:** never commit working specs; enforce by discipline, not git plumbing
+* **kotlin-sdk:** cite the Swift source in the signMessage KDoc, closes [#4259](https://github.com/dashpay/platform/issues/4259)
+
+
+### Continuous Integration
+
+* install Rust lint components for workspace tests ([#4294](https://github.com/dashpay/platform/issues/4294))
+* keep coverage-instrumented build between runs ([#4296](https://github.com/dashpay/platform/issues/4296))
+* lint test targets with clippy --all-targets ([#4330](https://github.com/dashpay/platform/issues/4330))
+* release Kotlin and Swift SDKs with the platform release ([#4228](https://github.com/dashpay/platform/issues/4228))
+* remove the CodeRabbit/PastaClaw AI review gate ([#4292](https://github.com/dashpay/platform/issues/4292))
+* schedule Rust workspace tests on macOS or Linux self-hosted runners ([#4287](https://github.com/dashpay/platform/issues/4287))
+* skip shielded Rust tests on PRs without shielded changes ([#4293](https://github.com/dashpay/platform/issues/4293))
+
+
+### Code Refactoring
+
+* **dpp:** extract shared try_from_schema parsing helpers ([#4276](https://github.com/dashpay/platform/issues/4276))
+* **rs-sdk-ffi:** use the rs-sdk voting-key helpers instead of its own ([#4341](https://github.com/dashpay/platform/issues/4341))
+* **sdk:** drop the vestigial v2 suffix from the finalized-transaction surface ([#4325](https://github.com/dashpay/platform/issues/4325))
+* **sdk:** remove deprecated v1 split build/sign transaction surface ([#4323](https://github.com/dashpay/platform/issues/4323))
+
+
+### Miscellaneous Chores
+
+* fix rustfmt drift on v4.2-dev ([#4278](https://github.com/dashpay/platform/issues/4278))
+* **platform-wallet:** bump key-wallet pin and migrate to new AddressState/asset-lock API ([#4305](https://github.com/dashpay/platform/issues/4305))
+* **swift-sdk:** remove Account.derivePrivateKeyWIF ([#4339](https://github.com/dashpay/platform/issues/4339))
+* update rust-dashcore to b056d07c ([#4343](https://github.com/dashpay/platform/issues/4343))
+
+
+### Tests
+
+* **drive-abci:** gate PR runs to one comprehensive chain simulation ([#4297](https://github.com/dashpay/platform/issues/4297))
+* **sdk:** add proof-vector regression corpus for drive-proof-verifier ([#4345](https://github.com/dashpay/platform/issues/4345))
+
 ## [4.1.0](https://github.com/dashpay/platform/compare/v4.0.0...v4.1.0) (2026-07-27)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "check-features"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "toml 0.8.23",
 ]
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "dash-async"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "dash-context-provider"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "dash-async",
  "dpp",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-balance-checker"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-macros"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "dashpay-contract",
  "document-history-contract",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "document-history-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2082,7 +2082,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dpns-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "dpp-json-convertible-derive"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "drive-abci"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "bincode",
  "dapi-grpc",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "assert_matches",
  "json-patch",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "base58",
  "platform-value",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5116,7 +5116,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-encryption"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "aes",
  "cbc",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "bincode",
  "platform-version",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value-convertible"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "bincode",
  "grovedb-version",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5232,7 +5232,7 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet-ffi"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet-storage"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "apple-native-keyring-store",
  "argon2",
@@ -6270,7 +6270,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "backon",
  "chrono",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dash-event-bus"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "metrics",
  "tokio",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-ffi"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-trusted-context-provider"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "arc-swap",
  "dash-async",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "rs-unified-sdk-ffi"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "dash-network",
  "key-wallet-ffi",
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "rs-unified-sdk-jni"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "android_logger",
  "dash-network",
@@ -7187,7 +7187,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-signer"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7323,7 +7323,7 @@ dependencies = [
 
 [[package]]
 name = "strategy-tests"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "bincode",
  "dpp",
@@ -7714,7 +7714,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8562,7 +8562,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8705,7 +8705,7 @@ checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
 
 [[package]]
 name = "wasm-dpp"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8729,7 +8729,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-dpp2"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-drive-verify"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8803,7 +8803,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sdk"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "base64 0.22.1",
  "bip39",
@@ -9312,7 +9312,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "4.1.0"
+version = "4.2.0-dev.1"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,5 +128,5 @@ opt-level = 3
 
 [workspace.package]
 
-version = "4.1.0"
+version = "4.2.0-dev.1"
 rust-version = "1.92"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/platform",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "private": true,
   "scripts": {
     "setup": "yarn install && yarn run build && yarn run configure",

--- a/packages/bench-suite/package.json
+++ b/packages/bench-suite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/bench-suite",
   "private": true,
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Dash Platform benchmark tool",
   "scripts": {
     "bench": "node ./bin/bench.js",

--- a/packages/dapi-grpc/package.json
+++ b/packages/dapi-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "DAPI GRPC definition file and generated clients",
   "browser": "browser.js",
   "main": "node.js",

--- a/packages/dapi/package.json
+++ b/packages/dapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/dapi",
   "private": true,
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "A decentralized API for the Dash network",
   "scripts": {
     "api": "node scripts/api.js",

--- a/packages/dash-spv/package.json
+++ b/packages/dash-spv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dash-spv",
-  "version": "4.2.0-dev.1",
+  "version": "5.2.0-dev.1",
   "description": "Repository containing SPV functions used by @dashevo",
   "main": "index.js",
   "scripts": {

--- a/packages/dash-spv/package.json
+++ b/packages/dash-spv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dash-spv",
-  "version": "5.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Repository containing SPV functions used by @dashevo",
   "main": "index.js",
   "scripts": {

--- a/packages/dashmate/package.json
+++ b/packages/dashmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashmate",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Distribution package for Dash node installation",
   "scripts": {
     "lint": "eslint .",

--- a/packages/dashpay-contract/package.json
+++ b/packages/dashpay-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashpay-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Reference contract of the DashPay DPA on Dash Evolution",
   "scripts": {
     "lint": "eslint .",

--- a/packages/document-history-contract/package.json
+++ b/packages/document-history-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/document-history-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "The document history contract",
   "scripts": {
     "lint": "eslint .",

--- a/packages/dpns-contract/package.json
+++ b/packages/dpns-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpns-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "A contract and helper scripts for DPNS DApp",
   "scripts": {
     "lint": "eslint .",

--- a/packages/js-dapi-client/package.json
+++ b/packages/js-dapi-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-client",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Client library used to access Dash DAPI endpoints",
   "main": "lib/index.js",
   "contributors": [

--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "4.2.0-dev.1",
+  "version": "7.2.0-dev.1",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "build/index.js",
   "unpkg": "dist/dash.min.js",

--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "7.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "build/index.js",
   "unpkg": "dist/dash.min.js",

--- a/packages/js-evo-sdk/package.json
+++ b/packages/js-evo-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/evo-sdk",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "type": "module",
   "main": "./dist/evo-sdk.module.js",
   "types": "./dist/sdk.d.ts",

--- a/packages/js-grpc-common/package.json
+++ b/packages/js-grpc-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/grpc-common",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Common GRPC library",
   "main": "index.js",
   "scripts": {

--- a/packages/keyword-search-contract/package.json
+++ b/packages/keyword-search-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/keyword-search-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "A contract that allows searching for contracts",
   "scripts": {
     "lint": "eslint .",

--- a/packages/masternode-reward-shares-contract/package.json
+++ b/packages/masternode-reward-shares-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/masternode-reward-shares-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "A contract and helper scripts for reward sharing",
   "scripts": {
     "lint": "eslint .",

--- a/packages/platform-test-suite/package.json
+++ b/packages/platform-test-suite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/platform-test-suite",
   "private": true,
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Dash Network end-to-end tests",
   "scripts": {
     "test": "yarn exec bin/test.sh",

--- a/packages/token-history-contract/package.json
+++ b/packages/token-history-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/token-history-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "The token history contract",
   "scripts": {
     "lint": "eslint .",

--- a/packages/wallet-lib/package.json
+++ b/packages/wallet-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "11.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Light wallet library for Dash",
   "main": "src/index.js",
   "unpkg": "dist/wallet-lib.min.js",

--- a/packages/wallet-lib/package.json
+++ b/packages/wallet-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "4.2.0-dev.1",
+  "version": "11.2.0-dev.1",
   "description": "Light wallet library for Dash",
   "main": "src/index.js",
   "unpkg": "dist/wallet-lib.min.js",

--- a/packages/wallet-utils-contract/package.json
+++ b/packages/wallet-utils-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-utils-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "A contract and helper scripts for Wallet DApp",
   "scripts": {
     "lint": "eslint .",

--- a/packages/wasm-dpp/package.json
+++ b/packages/wasm-dpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-dpp",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "The JavaScript implementation of the Dash Platform Protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wasm-dpp2/package.json
+++ b/packages/wasm-dpp2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-dpp2",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "type": "module",
   "main": "./dist/dpp.js",
   "types": "./dist/dpp.d.ts",

--- a/packages/wasm-drive-verify/package.json
+++ b/packages/wasm-drive-verify/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Dash Core Group <dev@dash.org>"
   ],
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "license": "MIT",
   "description": "WASM bindings for Drive verify functions",
   "repository": {

--- a/packages/wasm-sdk/package.json
+++ b/packages/wasm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-sdk",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "type": "module",
   "main": "./dist/sdk.js",
   "types": "./dist/sdk.d.ts",

--- a/packages/withdrawals-contract/package.json
+++ b/packages/withdrawals-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/withdrawals-contract",
-  "version": "4.1.0",
+  "version": "4.2.0-dev.1",
   "description": "Data Contract to manipulate and track withdrawals",
   "scripts": {
     "build": "",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Release new Dash Platform version

## What was done?
<!--- Describe your changes in detail -->
- Updated changelog
- Bumped packages version

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Published the `4.2.0-dev.1` development release across the platform and related packages.
  - Updated compatible SDK, wallet, contract, networking, and verification components to their corresponding development versions.

- **Documentation**
  - Added comprehensive release notes covering breaking changes, new capabilities, bug fixes, performance improvements, documentation updates, and quality improvements across the ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->