### PR TITLE
chore: bump rust-dashcore to the latest dev revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "dash-network",
 ]
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1805,12 +1805,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 
 [[package]]
 name = "glob"
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "aes",
  "async-trait",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=37b1a3615b908a2e0506920efce7e3babfada15f#37b1a3615b908a2e0506920efce7e3babfada15f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=36b49cb7f9c07ce8f2ed63f965489c50968d19f7#36b49cb7f9c07ce8f2ed63f965489c50968d19f7"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "37b1a3615b908a2e0506920efce7e3babfada15f" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "36b49cb7f9c07ce8f2ed63f965489c50968d19f7" }
 
 tokio-metrics = "0.5"
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The workspace was pinned to rust-dashcore `37b1a361`, which had fallen behind the upstream `dev` branch. This brings the pin up to the current `dev` head so platform builds against the latest core.

## What was done?

Bumped all eight rust-dashcore workspace dependencies in `Cargo.toml` from `37b1a361` to `36b49cb7f9c07ce8f2ed63f965489c50968d19f7`, and regenerated the corresponding 12 `Cargo.lock` entries with `cargo update -w`:

`dashcore`, `dash-network-seeds`, `dash-spv`, `key-wallet`, `key-wallet-ffi`, `key-wallet-manager`, `dash-network`, `dashcore-rpc`

The pin advances by exactly **one** upstream commit: `feat(dash-spv): accelerate compressed header sync` ([dashpay/rust-dashcore#950](https://github.com/dashpay/rust-dashcore/pull/950)).

### Reviewer notes

No platform source changes were needed. The upstream commit is confined to:

- `dash-spv/src/network/{manager,message_dispatcher}.rs`
- `dash-spv/src/sync/block_headers/{manager,pipeline,segment_state,sync_manager}.rs`
- `dash/src/network/message_headers2.rs` (the headers2 decoder)
- a new upstream test, `dash-spv/tests/header_dispatch_order.rs`

The only change touching a public type is a doc comment on `HashedBlockHeader::with_trusted_hash` in `dash-spv/src/types.rs` — no signature or behavioral change in the API surface platform consumes. The diff here is therefore limited to `Cargo.toml` and `Cargo.lock` (20 insertions / 20 deletions).

## How Has This Been Tested?

Both run locally on macOS (arm64) against the new pin, exit codes checked directly rather than through a pipe:

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — exit 0, no lint warnings

The single warning emitted is the pre-existing `default-features is ignored for dashcore` Cargo.toml note in `rs-dpp`, which is unrelated to this change and present before the bump.

Test suites were not run locally; CI coverage is relied on for those. Since the upstream delta is header-sync logic inside dash-spv, the SPV/wallet suites are the ones worth watching on this PR.

## Breaking Changes

None. No consensus-affecting code is touched, and no platform-side API changes were required.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal component versions to improve consistency and compatibility.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->