### PR TITLE
test(swift-sdk): make resolver sign tests hermetic to CI keychain state

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/KeychainSigner.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/KeychainSigner.swift
@@ -194,10 +194,14 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
     ///   - network: forwarded to `dash_sdk_signer_create_from_private_key`
     ///     for WIF address derivation; does not affect signature output.
     ///   - keychain: defaults to `KeychainManager.shared`.
+    ///   - storage: mnemonic source for the resolver-based signing
+    ///     paths. Defaults to a fresh `WalletStorage()` — overridable
+    ///     for tests.
     public init(
         modelContainer: ModelContainer,
         network: Network = .testnet,
-        keychain: KeychainManager = .shared
+        keychain: KeychainManager = .shared,
+        storage: WalletStorage = WalletStorage()
     ) {
         self.modelContainer = modelContainer
         self.network = network
@@ -206,7 +210,7 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
         // One resolver per signer instance. Cheap to keep around —
         // it's just an opaque handle + a Swift-side `WalletStorage`
         // reference. Used by the platform-address signing branch.
-        self.mnemonicResolver = MnemonicResolver()
+        self.mnemonicResolver = MnemonicResolver(storage: storage)
 
         // Hand Rust an opaque NON-owning pointer to self. The
         // Swift owner is responsible for keeping `self` alive

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/KeychainSigner.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/KeychainSigner.swift
@@ -180,6 +180,13 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
     /// swift-sdk/CLAUDE.md "no mnemonic round-tripping".
     private let mnemonicResolver: MnemonicResolver
 
+    /// The same `WalletStorage` handed to `mnemonicResolver`. The
+    /// `canSign` preflights consult it for `hasMnemonic` so preflight
+    /// and sign always answer from the same store — constructing a
+    /// fresh `WalletStorage()` there would desync the two when an
+    /// alternative storage is injected.
+    private let mnemonicStorage: WalletStorage
+
     /// Raw pointer to the FFI signer handle. Boxed by Rust and freed
     /// in `deinit`.
     private var handlePtr: OpaquePointer!
@@ -210,6 +217,7 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
         // One resolver per signer instance. Cheap to keep around —
         // it's just an opaque handle + a Swift-side `WalletStorage`
         // reference. Used by the platform-address signing branch.
+        self.mnemonicStorage = storage
         self.mnemonicResolver = MnemonicResolver(storage: storage)
 
         // Hand Rust an opaque NON-owning pointer to self. The
@@ -380,7 +388,7 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
             }
             // Existence check only — do NOT materialize the mnemonic
             // bytes on the preflight path.
-            return WalletStorage().hasMnemonic(for: resolved.walletId)
+            return mnemonicStorage.hasMnemonic(for: resolved.walletId)
         }
 
         var found = false
@@ -411,7 +419,7 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
                     wid.count == 32,
                     let path = row.identityDerivationPath,
                     !path.isEmpty,
-                    WalletStorage().hasMnemonic(for: wid)
+                    self.mnemonicStorage.hasMnemonic(for: wid)
                 {
                     found = true
                     return

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/IdentityResolverSignIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/IdentityResolverSignIntegrationTests.swift
@@ -17,6 +17,38 @@ final class IdentityResolverSignIntegrationTests: XCTestCase {
     private let mnemonic =
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
+    /// In-memory `WalletStorage` so the resolver path under test never
+    /// touches the real macOS Keychain — CI runners often have a locked
+    /// or permission-denied keychain session (`keychainError(-60008)` /
+    /// `(-61)`), which is an environment failure, not what these tests
+    /// cover. The lock mirrors the real storage's thread-safety: the
+    /// resolver trampoline reads from a Rust worker thread.
+    private final class InMemoryWalletStorage: WalletStorage {
+        private var mnemonics: [Data: Data] = [:]
+        private let lock = NSLock()
+
+        override func storeMnemonic(_ mnemonic: String, for walletId: Data) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            mnemonics[walletId] = Data(mnemonic.utf8)
+        }
+
+        override func retrieveMnemonicUTF8Bytes(for walletId: Data) throws -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+            guard let data = mnemonics[walletId], !data.isEmpty else {
+                throw WalletStorageError.mnemonicNotFound
+            }
+            return data
+        }
+
+        override func deleteMnemonic(for walletId: Data) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            mnemonics[walletId] = nil
+        }
+    }
+
     /// A consistent breadcrumb (the path derives to the row's pubkey) signs via
     /// the resolver: the seed is read from the Keychain, the key is derived on
     /// demand, the binding accepts it, and a 65-byte ECDSA signature comes back —
@@ -34,7 +66,7 @@ final class IdentityResolverSignIntegrationTests: XCTestCase {
         XCTAssertEqual(pubkey.count, 33, "compressed secp256k1 pubkey")
 
         // Seed the resolver's source: the mnemonic in WalletStorage, keyed by walletId.
-        let storage = WalletStorage()
+        let storage = InMemoryWalletStorage()
         try storage.storeMnemonic(mnemonic, for: walletId)
         defer { try? storage.deleteMnemonic(for: walletId) }
 
@@ -48,7 +80,7 @@ final class IdentityResolverSignIntegrationTests: XCTestCase {
         ctx.insert(row)
         try ctx.save()
 
-        let signer = KeychainSigner(modelContainer: container, network: .testnet)
+        let signer = KeychainSigner(modelContainer: container, network: .testnet, storage: storage)
         let message = Data("identity state transition".utf8)
         let result = signer.signIdentityKeyOnDemand(publicKey: pubkey, keyType: 0, data: message)
 
@@ -75,7 +107,7 @@ final class IdentityResolverSignIntegrationTests: XCTestCase {
         let wrongPath = try KeyDerivation.getIdentityAuthenticationPath(
             network: .testnet, identityIndex: 9, keyIndex: 9)
 
-        let storage = WalletStorage()
+        let storage = InMemoryWalletStorage()
         try storage.storeMnemonic(mnemonic, for: walletId)
         defer { try? storage.deleteMnemonic(for: walletId) }
 
@@ -88,7 +120,7 @@ final class IdentityResolverSignIntegrationTests: XCTestCase {
         ctx.insert(row)
         try ctx.save()
 
-        let signer = KeychainSigner(modelContainer: container, network: .testnet)
+        let signer = KeychainSigner(modelContainer: container, network: .testnet, storage: storage)
         let result = signer.signIdentityKeyOnDemand(
             publicKey: pubkey, keyType: 0, data: Data("x".utf8))
 

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/IdentityResolverSignIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/IdentityResolverSignIntegrationTests.swift
@@ -47,6 +47,13 @@ final class IdentityResolverSignIntegrationTests: XCTestCase {
             defer { lock.unlock() }
             mnemonics[walletId] = nil
         }
+
+        // `hasMnemonic` (the `canSign` preflight) delegates here.
+        override func mnemonicAvailability(for walletId: Data) -> MnemonicAvailability {
+            lock.lock()
+            defer { lock.unlock() }
+            return mnemonics[walletId] != nil ? .present : .absent
+        }
     }
 
     /// A consistent breadcrumb (the path derives to the row's pubkey) signs via
@@ -81,6 +88,11 @@ final class IdentityResolverSignIntegrationTests: XCTestCase {
         try ctx.save()
 
         let signer = KeychainSigner(modelContainer: container, network: .testnet, storage: storage)
+
+        // The preflight consults the same injected storage as the sign
+        // path, so a resolver-signable key must report signable.
+        XCTAssertTrue(signer.canSign(publicKey: pubkey, keyType: 0))
+
         let message = Data("identity state transition".utf8)
         let result = signer.signIdentityKeyOnDemand(publicKey: pubkey, keyType: 0, data: message)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The "Swift SDK build + tests (warnings as errors)" job fails intermittently on the self-hosted mac runners with `keychainError` from `WalletStorage` — `-60008` (`errAuthorizationInternal`) on mac-runner-2 and now `-61` (`errSecWrPerm`) on mac-runner-1 (e.g. [this run](https://github.com/dashpay/platform/actions/runs/31647547581/job/94288489188) on an unrelated PR). The two `IdentityResolverSignIntegrationTests` cases were the only tests in the `swift test` phase writing to the real macOS keychain, so they fail whenever a runner's keychain session is locked or permission-denied — even with the dedicated CI keychain `run_tests.sh` provisions.

## What was done?

- `KeychainSigner.init` now accepts an injectable `WalletStorage` (defaulting to the real one), forwarded to its `MnemonicResolver` — the same "overridable for tests" pattern already used by `MnemonicResolver` and `ManagedPlatformWallet`.
- `IdentityResolverSignIntegrationTests` uses an in-memory `WalletStorage` subclass, so the derive-sign-destroy resolver path under test never touches keychain state.

## How Has This Been Tested?

- `swift test --filter IdentityResolverSignIntegrationTests` — both tests pass, with the resolver trampoline confirmed firing through the injected storage.
- Full `swift test`: 349 tests, 0 failures.

## Breaking Changes

None — the new parameter is defaulted; existing call sites are unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for providing custom wallet storage when initializing the keychain signer.
  * The default wallet storage behavior remains unchanged.

* **Tests**
  * Improved integration test reliability by using isolated in-memory wallet storage instead of the system keychain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->