### PR TITLE
build(dashmate): track the floating Tenderdash 1.6 image tag

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -358,7 +358,7 @@ export default function getBaseConfigFactory() {
           tenderdash: {
             mode: 'full',
             docker: {
-              image: 'dashpay/tenderdash:1.6.0',
+              image: 'dashpay/tenderdash:1.6',
             },
             p2p: {
               host: '0.0.0.0',

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1638,6 +1638,46 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '4.1.1': (configFile) => {
+        // The drive and rs-dapi tags are derived from the package version, and
+        // the migration that re-pins them no longer fires for a config already
+        // stamped at the release that set it. This release is the next one above
+        // that stamp, so it carries the re-pin forward for a config that never
+        // crossed it.
+        //
+        // Only tags a release published are moved, so a tag the operator chose
+        // in this namespace (dashpay/drive:4-local) is left alone.
+        const stockDriveImage = stockImagePattern('dashpay/drive', 4);
+        const stockRsDapiImage = stockImagePattern('dashpay/rs-dapi', 4);
+
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            // Move the Tenderdash image onto the floating minor tag the base
+            // config now pins, so a patch release published on that line is
+            // picked up without a Dashmate release. Configs written while the
+            // base config pinned an exact version hold that version, and only a
+            // migration moves them off it. Pulled from the base config so it
+            // tracks whatever is pinned there.
+            // Keyed at the next release, not the released 4.1.0: the runner
+            // skips fromVersion===toVersion, so a key equal to an operator's
+            // current version never fires.
+            if (options.platform?.drive?.tenderdash?.docker) {
+              options.platform.drive.tenderdash.docker.image = base.get('platform.drive.tenderdash.docker.image');
+            }
+
+            const driveDocker = options.platform?.drive?.abci?.docker;
+            if (driveDocker && stockDriveImage.test(driveDocker.image)) {
+              driveDocker.image = base.get('platform.drive.abci.docker.image');
+            }
+
+            const rsDapiDocker = options.platform?.dapi?.rsDapi?.docker;
+            if (rsDapiDocker && stockRsDapiImage.test(rsDapiDocker.image)) {
+              rsDapiDocker.image = base.get('platform.dapi.rsDapi.docker.image');
+            }
+          });
+
+        return configFile;
+      },
     };
   }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The base config pinned `dashpay/tenderdash:1.6.0`, so a Tenderdash patch release published on the 1.6 line only reached operators through a Dashmate release. Pinning the floating minor tag lets Docker resolve the latest 1.6.x instead (`1.6` currently resolves to 1.6.0, digest `766bdca9`).

Config files store resolved values, so changing the base config alone does not move an existing node. The last migration to re-pin this image ran at `4.0.0-rc.3`, so every config written or migrated since holds the exact version that release pinned — a tag nothing moves.

## What was done?

- `packages/dashmate/configs/defaults/getBaseConfigFactory.js` — `dashpay/tenderdash:1.6.0` → `dashpay/tenderdash:1.6`.
- `packages/dashmate/configs/getConfigFileMigrationsFactory.js` — new `4.1.1` migration moving an existing config's Tenderdash image onto whatever the base config pins.

Keyed at `4.1.1` rather than the released `4.1.0`: the runner returns early on `fromVersion === toVersion`, so a key equal to an operator's current version never fires. This matches the reasoning recorded on the `4.0.0-rc.3` and `4.1.0-rc.2` entries.

The migration also carries the **drive and rs-dapi re-pin** forward from the `4.1.0` entry. Those tags are derived from the package version, and the entry that re-pins them stops firing once a config is stamped at it, so the newest key has to hold the re-pin. Without it, `migrateConfigFileFactory`'s existing table walk fails for a config stamped `4.1.0` while still carrying `dashpay/drive:4-rc`.

### Trade-off worth a reviewer's attention

A floating tag costs reproducibility. Two nodes on the same Dashmate version can run different Tenderdash binaries depending on when they last pulled, and a bad 1.6.x publish reaches every node with no Dashmate release or changelog entry to bisect against. Tenderdash is consensus-critical, so the blast radius is network-wide rather than per-operator. Implemented as specified; flagging it for the merge decision.

## How Has This Been Tested?

- `yarn workspace dashmate test:unit` → **158 passing, 0 failing**.
- `migrateConfigFileFactory.spec.js` → 4 passing, including the table walk that pins the drive/rs-dapi re-pin described above.
- `yarn eslint` on both changed files → clean.
- Verified through the real DI container (`createConfigFile` + `migrateConfigFile`): the base config emits `dashpay/tenderdash:1.6`, and a config stamped `4.1.0` holding `dashpay/tenderdash:1.6.0` migrates to `dashpay/tenderdash:1.6` (it stays on `1.6.0` with the migration removed).

A regression test pinning that 4.0.x/4.1.x cohort was written and confirmed red→green, then dropped at the owner's request; the pre-existing table walk still fails if the drive/rs-dapi re-pin is removed.

Note for in-flight `v4.2-dev`: under the `getConfigFormatVersion` mechanism added there, a config already stamped `4.2.0` by an in-cycle dev build skips every key at or below `4.2.0`, including this one. Those operators need `dashmate config set platform.drive.tenderdash.docker.image dashpay/tenderdash:1.6`. Not introduced by this key choice — no key at or below `4.2.0` can reach them.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)