### PR TITLE
build(dashmate)!: pin Tenderdash to the 1.7 line and drop the removed Commit timeout overrides

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -358,7 +358,7 @@ export default function getBaseConfigFactory() {
           tenderdash: {
             mode: 'full',
             docker: {
-              image: 'dashpay/tenderdash:1.6',
+              image: 'dashpay/tenderdash:1.7',
             },
             p2p: {
               host: '0.0.0.0',

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -416,10 +416,6 @@ export default function getBaseConfigFactory() {
                   timeout: null,
                   delta: null,
                 },
-                commit: {
-                  timeout: null,
-                  bypass: null,
-                },
               },
             },
             log: {

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1674,6 +1674,12 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
             if (rsDapiDocker && stockRsDapiImage.test(rsDapiDocker.image)) {
               rsDapiDocker.image = base.get('platform.dapi.rsDapi.docker.image');
             }
+
+            // The Commit timeout and BypassCommitTimeout overrides no longer
+            // exist in Tenderdash, which now only warns when they are set.
+            // Drop them: the config schema accepts no properties it does not
+            // define, so a config that kept them would fail validation.
+            delete options.platform?.drive?.tenderdash?.consensus?.unsafeOverride?.commit;
           });
 
         return configFile;

--- a/packages/dashmate/docs/config/tenderdash.md
+++ b/packages/dashmate/docs/config/tenderdash.md
@@ -144,8 +144,6 @@ These settings control the consensus mechanism:
 | `platform.drive.tenderdash.consensus.unsafeOverride.propose.delta` | Delta for propose phase | `500ms` | `1s` |
 | `platform.drive.tenderdash.consensus.unsafeOverride.vote.timeout` | Timeout for vote phase | `1s` | `2s` |
 | `platform.drive.tenderdash.consensus.unsafeOverride.vote.delta` | Delta for vote phase | `500ms` | `1s` |
-| `platform.drive.tenderdash.consensus.unsafeOverride.commit.timeout` | Timeout for commit phase | `1s` | `2s` |
-| `platform.drive.tenderdash.consensus.unsafeOverride.commit.bypass` | Whether to bypass commit phase | `false` | `true` |
 
 Consensus configuration example:
 ```json
@@ -165,10 +163,6 @@ Consensus configuration example:
       "vote": {
         "timeout": "1s",
         "delta": "500ms"
-      },
-      "commit": {
-        "timeout": "1s",
-        "bypass": false
       }
     }
   }

--- a/packages/dashmate/src/config/configJsonSchema.js
+++ b/packages/dashmate/src/config/configJsonSchema.js
@@ -1238,22 +1238,9 @@ export default {
                           additionalProperties: false,
                           required: ['timeout', 'delta'],
                         },
-                        commit: {
-                          type: 'object',
-                          properties: {
-                            timeout: {
-                              $ref: '#/definitions/optionalDuration',
-                            },
-                            bypass: {
-                              type: ['boolean', 'null'],
-                            },
-                          },
-                          additionalProperties: false,
-                          required: ['timeout', 'bypass'],
-                        },
                       },
                       additionalProperties: false,
-                      required: ['propose', 'vote', 'commit'],
+                      required: ['propose', 'vote'],
                     },
                   },
                   additionalProperties: false,

--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -526,27 +526,6 @@ unsafe-vote-timeout-override = "{{= it.platform.drive.tenderdash.consensus.unsaf
 unsafe-vote-timeout-delta-override = "{{= it.platform.drive.tenderdash.consensus.unsafeOverride.vote.delta }}"
 {{?}}
 
-# This field provides an unsafe override of the Commit timeout consensus parameter.
-# This field configures how long the consensus engine will wait after receiving
-# +2/3 precommits before beginning the next height.
-# If this field is set to a value greater than 0, it will take effect.
-{{? it.platform.drive.tenderdash.consensus.unsafeOverride.commit.timeout === null }}
-# unsafe-commit-timeout-override = 0s
-{{??}}
-unsafe-commit-timeout-override = "{{= it.platform.drive.tenderdash.consensus.unsafeOverride.commit.timeout }}"
-{{?}}
-
-# This field provides an unsafe override of the BypassCommitTimeout consensus parameter.
-# This field configures if the consensus engine will wait for the full Commit timeout
-# before proceeding to the next height.
-# If this field is set to true, the consensus engine will proceed to the next height
-# as soon as the node has gathered votes from all of the validators on the network.
-{{? it.platform.drive.tenderdash.consensus.unsafeOverride.commit.bypass === null }}
-# unsafe-bypass-commit-timeout-override =
-{{??}}
-unsafe-bypass-commit-timeout-override = {{? it.platform.drive.tenderdash.consensus.unsafeOverride.commit.bypass }}true{{??}}false{{?}}
-{{?}}
-
 
 #######################################################
 ###   Transaction Indexer Configuration Options     ###


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two changes for the **4.1.1** release, both following Tenderdash onto the 1.7 line:

1. The base config's Tenderdash image moves onto the 1.7 line.
2. `consensus.unsafeOverride.commit.{timeout,bypass}` is dead config surface. Tenderdash 1.7 no longer honours `unsafe-commit-timeout-override` or `unsafe-bypass-commit-timeout-override` — in `release/v1.7.0` both are renamed to `DeprecatedUnsafeCommitTimeoutOverride`/`DeprecatedUnsafeBypassCommitTimeoutOverride`, dropped from the emitted `config/toml.go`, and setting either only produces a startup warning.

## What was done?

**Image pin** — `configs/defaults/getBaseConfigFactory.js`: `dashpay/tenderdash:1.6` → `dashpay/tenderdash:1.7`. No migration needed for this: the `'4.1.1'` migration from #4410 reads `base.get('platform.drive.tenderdash.docker.image')` and 4.1.1 is unreleased, so it delivers this value to every existing config when the version bumps.

**Removing the dead overrides** touches five places:

- `templates/platform/drive/tenderdash/config.toml.dot` — the two emitted blocks
- `configs/defaults/getBaseConfigFactory.js` — the `commit` defaults
- `src/config/configJsonSchema.js` — the `commit` properties, and `commit` from `unsafeOverride`'s `required`
- `docs/config/tenderdash.md` — the two documented options and the `commit` branch of the example
- `configs/getConfigFileMigrationsFactory.js` — the `'4.1.1'` migration deletes `consensus.unsafeOverride.commit`

That migration is **required, not cosmetic**. Every object in the schema is `additionalProperties: false`, so a config that kept the branch is rejected outright — verified both ways:

```
migrated config valid : true
kept-commit config    : rejected -> data/platform/drive/tenderdash/consensus/unsafeOverride must NOT have additional properties
new Config(stale)     : InvalidOptionsError: config/platform/drive/tenderdash/consensus/unsafeOverride must NOT have additional properties
```

Without it, every Dashmate command would fail after the upgrade until an operator hand-edited the file. Extending the unreleased `'4.1.1'` entry reaches exactly the same operators as a new key would.

## How Has This Been Tested?

- Rendered `platform/drive/tenderdash/config.toml` from the testnet config through `renderServiceTemplates` — the template still parses (a `.dot` error only shows at render time), `[consensus]` is intact, the four `propose`/`vote` overrides are still emitted commented-out, and no `commit-timeout` line remains.
- Schema and `Config` constructor behaviour as quoted above; the `'4.1.1'` migration strips the branch from all four configs (`base`, `local`, `testnet`, `mainnet`).
- Base config emits `dashpay/tenderdash:1.7`, and a config stamped `4.1.0` migrates to it from `1.6`, `1.6.0`, or `1.5`.
- `yarn workspace dashmate test:unit` → **158 passing, 0 failing**. `yarn eslint` on all changed paths → clean.
- Not exercised against a running node — a platform-test-suite run against the real 1.7 image is still outstanding.

## Breaking Changes

`platform.drive.tenderdash.consensus.unsafeOverride.commit.timeout` and `.bypass` are removed from the config. An operator who set either loses the value on upgrade; nothing changes in behaviour, because Tenderdash 1.7 ignores both and only warns.

## Note for the reviewer

`packages/rs-drive-abci/Cargo.toml:54` pins `tenderdash-abci` at `v1.5.1`, the newest tag `rs-tenderdash-abci` has. If Tenderdash 1.7 changes the ABCI protocol, that pin needs a matching bump — it is not covered here.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
