### PR TITLE
fix(dashmate): handle nullable ZeroSSL expiry dates

### DIFF
--- a/packages/dashmate/src/helper/scheduleRenewZeroSslCertificateFactory.js
+++ b/packages/dashmate/src/helper/scheduleRenewZeroSslCertificateFactory.js
@@ -53,7 +53,14 @@ export default function scheduleRenewZeroSslCertificateFactory(
     }
 
     let expiresAt;
-    if (certificate.isExpiredInDays(Certificate.EXPIRATION_LIMIT_DAYS)) {
+    if (certificate.expires === null) {
+      // A draft or pending certificate has no expiry date yet. Resume its
+      // obtain flow instead of passing a date in the past to cron.
+      expiresAt = new Date(Date.now() + 3000);
+
+      // eslint-disable-next-line no-console
+      console.log(`SSL certificate ${certificate.id} has not been issued yet. Schedule to obtain it NOW.`);
+    } else if (certificate.isExpiredInDays(Certificate.EXPIRATION_LIMIT_DAYS)) {
       // Obtain new certificate right away
       expiresAt = new Date(Date.now() + 3000);
 

--- a/packages/dashmate/src/ssl/zerossl/Certificate.js
+++ b/packages/dashmate/src/ssl/zerossl/Certificate.js
@@ -16,7 +16,7 @@ export default class Certificate {
   created;
 
   /**
-   * @type {Date}
+   * @type {Date|null}
    */
   expires;
 
@@ -35,7 +35,8 @@ export default class Certificate {
    * @param {string} object.common_name - The common name of the certificate.
    * @param {string} object.additional_domains - Any additional domains in the certificate.
    * @param {string} object.created - The exact time the certificate was created.
-   * @param {string} object.expires - The exact time the certificate will expire.
+   * @param {string|null} object.expires - The exact time the certificate will expire,
+   * or null until the certificate is issued.
    * @param {string} object.status - The current certificate status.
    * @param {string|null} object.validation_type - The selected verification type, or null
    * if not initiated.
@@ -64,7 +65,7 @@ export default class Certificate {
    * the CNAME-record for domain verification.
    */
   constructor(object) {
-    const expires = convertDate(object.expires);
+    const expires = object.expires === null ? null : convertDate(object.expires);
     const created = convertDate(object.created);
 
     Object.assign(this, {
@@ -105,6 +106,10 @@ export default class Certificate {
    * @param {number} days
    */
   isExpiredInDays(days) {
+    if (this.expires === null) {
+      return false;
+    }
+
     const expiresInDays = new Date(this.expires);
     expiresInDays.setDate(expiresInDays.getDate() - days);
 

--- a/packages/dashmate/test/unit/helper/scheduleRenewZeroSslCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/helper/scheduleRenewZeroSslCertificateFactory.spec.js
@@ -65,4 +65,33 @@ describe('scheduleRenewZeroSslCertificateFactory', () => {
       expect(setTimeoutStub.firstCall.args[1]).to.equal(60 * 60 * 1000);
     });
   });
+
+  it('should resume obtaining a pending certificate that has no expiry date', async function it() {
+    const clock = this.sinon.useFakeTimers({
+      now: new Date('2026-08-19T00:00:00.000Z'),
+    });
+    this.sinon.stub(console, 'log');
+
+    const certificate = {
+      id: 'pending-certificate-id',
+      status: 'pending_validation',
+      expires: null,
+      isExpiredInDays: this.sinon.stub().returns(false),
+    };
+    const tasks = {
+      run: this.sinon.stub().resolves(),
+    };
+
+    getCertificate.resolves(certificate);
+    obtainZeroSSLCertificateTask.returns(tasks);
+
+    await scheduleRenewZeroSslCertificate(config);
+    await clock.tickAsync(3000);
+
+    expect(obtainZeroSSLCertificateTask).to.have.been.calledOnceWithExactly(config);
+    expect(tasks.run).to.have.been.calledOnceWithExactly({
+      expirationDays: 3,
+      noRetry: true,
+    });
+  });
 });

--- a/packages/dashmate/test/unit/ssl/zerossl/Certificate.spec.js
+++ b/packages/dashmate/test/unit/ssl/zerossl/Certificate.spec.js
@@ -1,0 +1,14 @@
+import Certificate from '../../../../src/ssl/zerossl/Certificate.js';
+
+describe('Certificate', () => {
+  it('should handle a pending certificate without an expiration date', () => {
+    const certificate = new Certificate({
+      status: 'pending_validation',
+      created: '2026-08-18 09:04:19',
+      expires: null,
+    });
+
+    expect(certificate.expires).to.be.null();
+    expect(certificate.isExpiredInDays(30)).to.be.false();
+  });
+});


### PR DESCRIPTION
## Issue being fixed or feature implemented

`dashmate ssl obtain` aborts with `Cannot read properties of null (reading 'split')` when ZeroSSL returns a draft or pending certificate. ZeroSSL documents `expires` as `null` until the certificate is issued, but Dashmate previously parsed it as an unconditional date string.

## What was done?

- Preserve the nullable expiry while a ZeroSSL certificate is not yet issued.
- Treat a certificate without an expiry as not expired so the validation flow can continue.
- Add regression coverage using the pending-certificate response shape.

## How Has This Been Tested?

- The focused regression test failed with the reported `null.split` error before the fix and passes after it.
- All ZeroSSL unit specs pass: 13 tests.
- ESLint reports no errors in the changed files. It retains one pre-existing unused suppression warning in `Certificate.js`.
- The complete Dashmate unit suite could not start because this worktree does not contain the generated `packages/wasm-dpp/dist/index.js` artifact.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
