### PR TITLE
fix(dashmate): detect and report gateway certificate problems

### DIFF
--- a/packages/dashmate/src/commands/ssl/obtain.js
+++ b/packages/dashmate/src/commands/ssl/obtain.js
@@ -1,5 +1,6 @@
 import { Listr } from 'listr2';
 import { Flags } from '@oclif/core';
+import ServiceIsNotRunningError from '../../docker/errors/ServiceIsNotRunningError.js';
 import ConfigBaseCommand from '../../oclif/command/ConfigBaseCommand.js';
 import MuteOneLineError from '../../oclif/errors/MuteOneLineError.js';
 import Certificate from '../../ssl/zerossl/Certificate.js';
@@ -96,9 +97,22 @@ Certificate will be renewed if it is about to expire (see 'expiration-days' flag
           // so the command reports success while nothing changes for clients.
           title: 'Reload gateway',
           enabled: () => config.get('platform.enable'),
-          skip: async () => !(await dockerCompose.isServiceRunning(config, 'gateway'))
-            && 'Gateway is not running, the certificate will be used when it starts',
-          task: async () => dockerCompose.execCommand(config, 'gateway', 'kill -SIGHUP 1'),
+          // Asking whether the gateway is running before signalling it would answer a question
+          // that can stop being true before the signal is sent, and the certificate has already
+          // been obtained by this point - failing here would send the operator back to a
+          // provider that has nothing left to give. execCommand makes the same check itself,
+          // so a gateway that is down is taken as nothing to reload.
+          task: async (ctx, listrTask) => {
+            try {
+              await dockerCompose.execCommand(config, 'gateway', 'kill -SIGHUP 1');
+            } catch (e) {
+              if (!(e instanceof ServiceIsNotRunningError)) {
+                throw e;
+              }
+
+              listrTask.skip('Gateway is not running, the certificate will be used when it starts');
+            }
+          },
         },
       ],
       {

--- a/packages/dashmate/src/commands/ssl/obtain.js
+++ b/packages/dashmate/src/commands/ssl/obtain.js
@@ -40,6 +40,7 @@ Certificate will be renewed if it is about to expire (see 'expiration-days' flag
    * @param {obtainLetsEncryptCertificateTask} obtainLetsEncryptCertificateTask
    * @param {ConfigFileJsonRepository} configFileRepository
    * @param {ConfigFile} configFile
+   * @param {DockerCompose} dockerCompose
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -56,6 +57,7 @@ Certificate will be renewed if it is about to expire (see 'expiration-days' flag
     obtainLetsEncryptCertificateTask,
     configFileRepository,
     configFile,
+    dockerCompose,
   ) {
     const provider = providerFlag || config.get('platform.gateway.ssl.provider');
 
@@ -87,6 +89,16 @@ Certificate will be renewed if it is about to expire (see 'expiration-days' flag
         {
           title: taskTitle,
           task: () => task(config, taskOptions),
+        },
+        {
+          // Writing the certificate files does not change what the gateway serves. Without
+          // this it keeps presenting the previous certificate until the node is restarted,
+          // so the command reports success while nothing changes for clients.
+          title: 'Reload gateway',
+          enabled: () => config.get('platform.enable'),
+          skip: async () => !(await dockerCompose.isServiceRunning(config, 'gateway'))
+            && 'Gateway is not running, the certificate will be used when it starts',
+          task: async () => dockerCompose.execCommand(config, 'gateway', 'kill -SIGHUP 1'),
         },
       ],
       {

--- a/packages/dashmate/src/createDIContainer.js
+++ b/packages/dashmate/src/createDIContainer.js
@@ -18,6 +18,7 @@ import createConfigFileFactory from './config/configFile/createConfigFileFactory
 import migrateConfigFileFactory from './config/configFile/migrateConfigFileFactory.js';
 import DefaultConfigs from './config/DefaultConfigs.js';
 import analyseConfigFactory from './doctor/analyse/analyseConfigFactory.js';
+import analyseGatewayCertificateFactory from './doctor/analyse/analyseGatewayCertificateFactory.js';
 import analyseCoreFactory from './doctor/analyse/analyseCoreFactory.js';
 import analysePlatformFactory from './doctor/analyse/analysePlatformFactory.js';
 import analyseServiceContainersFactory from './doctor/analyse/analyseServiceContainersFactory.js';
@@ -365,6 +366,7 @@ export default async function createDIContainer(options = {}) {
     analyseSystemResources: asFunction(analyseSystemResourcesFactory).singleton(),
     analyseServiceContainers: asFunction(analyseServiceContainersFactory).singleton(),
     analyseConfig: asFunction(analyseConfigFactory).singleton(),
+    analyseGatewayCertificate: asFunction(analyseGatewayCertificateFactory).singleton(),
     analyseCore: asFunction(analyseCoreFactory).singleton(),
     analysePlatform: asFunction(analysePlatformFactory).singleton(),
     unarchiveSamples: asFunction(unarchiveSamplesFactory).singleton(),

--- a/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
@@ -154,6 +154,12 @@ and revoke the previous certificate in the ZeroSSL dashboard`,
                 description: chalk`Let's Encrypt certificate expires at ${ssl?.data?.certificate?.expires}.`,
                 solution: chalk`Please run {bold.cyanBright dashmate ssl obtain --provider=letsencrypt} to renew`,
               },
+              [LETSENCRYPT_ERRORS.CERTIFICATE_NOT_INSTALLED]: {
+                description: chalk`A renewed Let's Encrypt certificate has not been installed for the gateway.`,
+                solution: chalk`The gateway keeps serving the previous certificate until it is reloaded,
+and will stop accepting clients when that one expires.
+Please restart the node: {bold.cyanBright dashmate restart}`,
+              },
               [LETSENCRYPT_ERRORS.CERTIFICATE_NOT_VALID]: {
                 description: chalk`Let's Encrypt certificate is not valid.`,
                 solution: chalk`Please run {bold.cyanBright dashmate ssl obtain --provider=letsencrypt --force} to get a new one.`,

--- a/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
@@ -7,16 +7,13 @@ import Problem from '../Problem.js';
 
 /**
  * Whether a ZeroSSL certificate can be renewed depends on the operator's plan, which dashmate
- * cannot see. Both routes are offered rather than assuming which one applies, and the cost of
- * switching is stated so the choice is an informed one.
+ * cannot see, so both routes are offered rather than assuming which one applies.
  */
-const LETSENCRYPT_ALTERNATIVE = chalk`Or switch to Let's Encrypt, which issues certificates for IP addresses free of
-charge and renews them automatically:
+const LETSENCRYPT_ALTERNATIVE = chalk`Or switch to Let's Encrypt, which issues certificates for IP addresses free
+of charge:
   {bold.cyanBright dashmate config set platform.gateway.ssl.provider letsencrypt}
   {bold.cyanBright dashmate config set platform.gateway.ssl.providerConfigs.letsencrypt.email EMAIL}
-  {bold.cyanBright dashmate ssl obtain}
-Its certificates for IP addresses are valid for 6 days and renew every few days on
-their own, rather than the 90 days a ZeroSSL certificate lasts.`;
+  {bold.cyanBright dashmate ssl obtain}`;
 
 export default function analyseConfigFactory() {
   /**

--- a/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
@@ -60,10 +60,7 @@ export default function analyseConfigFactory() {
             }
             break;
           default: {
-            const {
-              description,
-              solution,
-            } = {
+            const fileProblems = {
               // File provider error
               'not-valid': {
                 description: 'SSL certificate files are not valid',
@@ -82,15 +79,17 @@ Private key file path: {bold.cyanBright ${ssl?.data?.privateFilePath}}
 
 Or use ZeroSSL https://docs.dash.org/en/stable/masternodes/dashmate.html#ssl-certificate`,
               },
-              // ZeroSSL validation errors
+            };
+
+            const zeroSslProblems = {
               [ZEROSSL_ERRORS.API_KEY_IS_NOT_SET]: {
                 description: 'ZeroSSL API key is not set.',
                 solution: chalk`Please obtain your API key from {underline.cyanBright https://app.zerossl.com/developer}
-And then update your configuration with {block.cyanBright dashmate config set platform.gateway.ssl.providerConfigs.zerossl.apiKey [KEY]}`,
+And then update your configuration with {bold.cyanBright dashmate config set platform.gateway.ssl.providerConfigs.zerossl.apiKey [KEY]}`,
               },
               [ZEROSSL_ERRORS.EXTERNAL_IP_IS_NOT_SET]: {
                 description: 'External IP is not set.',
-                solution: chalk`Please update your configuration to include your external IP using {block.cyanBright dashmate config set externalIp [IP]}`,
+                solution: chalk`Please update your configuration to include your external IP using {bold.cyanBright dashmate config set externalIp [IP]}`,
               },
               [ZEROSSL_ERRORS.CERTIFICATE_ID_IS_NOT_SET]: {
                 description: 'ZeroSSL certificate is not configured',
@@ -102,7 +101,7 @@ And then update your configuration with {block.cyanBright dashmate config set pl
 and revoke the previous certificate in the ZeroSSL dashboard`,
               },
               [ZEROSSL_ERRORS.EXTERNAL_IP_MISMATCH]: {
-                description: chalk`ZeroSSL IP ${ssl?.data?.certificate.common_name} does not match external IP ${ssl?.data?.externalIp}.`,
+                description: chalk`ZeroSSL IP ${ssl?.data?.certificate?.common_name} does not match external IP ${ssl?.data?.externalIp}.`,
                 solution: chalk`Please regenerate the certificate using {bold.cyanBright dashmate ssl obtain --force}
             and revoke the previous certificate in the ZeroSSL dashboard`,
               },
@@ -113,7 +112,7 @@ This makes auto-renewal impossible.`,
 and revoke the previous certificate in the ZeroSSL dashboard`,
               },
               [ZEROSSL_ERRORS.CERTIFICATE_EXPIRES_SOON]: {
-                description: chalk`ZeroSSL certificate expires at ${ssl?.data?.certificate.expires}.`,
+                description: chalk`ZeroSSL certificate expires at ${ssl?.data?.certificate?.expires}.`,
                 solution: chalk`Please run {bold.cyanBright dashmate ssl obtain} to get a new one`,
               },
               [ZEROSSL_ERRORS.CERTIFICATE_IS_NOT_VALIDATED]: {
@@ -128,7 +127,9 @@ and revoke the previous certificate in the ZeroSSL dashboard`,
                 description: ssl?.data?.error?.message,
                 solution: chalk`Please contact ZeroSSL support if needed.`,
               },
-              // Let's Encrypt validation errors
+            };
+
+            const letsEncryptProblems = {
               [LETSENCRYPT_ERRORS.EMAIL_IS_NOT_SET]: {
                 description: 'Let\'s Encrypt email is not set.',
                 solution: chalk`Please update your configuration with {bold.cyanBright dashmate config set platform.gateway.ssl.providerConfigs.letsencrypt.email [EMAIL]}`,
@@ -157,6 +158,21 @@ and revoke the previous certificate in the ZeroSSL dashboard`,
                 description: chalk`Let's Encrypt certificate is not valid.`,
                 solution: chalk`Please run {bold.cyanBright dashmate ssl obtain --provider=letsencrypt --force} to get a new one.`,
               },
+            };
+
+            // Both providers report some errors under the same name, so only the
+            // configured provider's messages are considered. Otherwise one provider's
+            // message would describe a problem found by the other one.
+            const providerProblems = config.get('platform.gateway.ssl.provider') === 'letsencrypt'
+              ? letsEncryptProblems
+              : zeroSslProblems;
+
+            const {
+              description,
+              solution,
+            } = {
+              ...fileProblems,
+              ...providerProblems,
             }[ssl.error] ?? {};
 
             if (description) {

--- a/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
@@ -5,6 +5,19 @@ import { ERRORS as ZEROSSL_ERRORS } from '../../ssl/zerossl/validateZeroSslCerti
 import { SEVERITY } from '../Prescription.js';
 import Problem from '../Problem.js';
 
+/**
+ * Whether a ZeroSSL certificate can be renewed depends on the operator's plan, which dashmate
+ * cannot see. Both routes are offered rather than assuming which one applies, and the cost of
+ * switching is stated so the choice is an informed one.
+ */
+const LETSENCRYPT_ALTERNATIVE = chalk`Or switch to Let's Encrypt, which issues certificates for IP addresses free of
+charge and renews them automatically:
+  {bold.cyanBright dashmate config set platform.gateway.ssl.provider letsencrypt}
+  {bold.cyanBright dashmate config set platform.gateway.ssl.providerConfigs.letsencrypt.email EMAIL}
+  {bold.cyanBright dashmate ssl obtain}
+Its certificates for IP addresses are valid for 6 days and renew every few days on
+their own, rather than the 90 days a ZeroSSL certificate lasts.`;
+
 export default function analyseConfigFactory() {
   /**
    * @typedef analyseConfig
@@ -113,7 +126,10 @@ and revoke the previous certificate in the ZeroSSL dashboard`,
               },
               [ZEROSSL_ERRORS.CERTIFICATE_EXPIRES_SOON]: {
                 description: chalk`ZeroSSL certificate expires at ${ssl?.data?.certificate?.expires}.`,
-                solution: chalk`Please run {bold.cyanBright dashmate ssl obtain} to get a new one`,
+                solution: chalk`Please run {bold.cyanBright dashmate ssl obtain} to get a new one, which needs an
+available certificate on your ZeroSSL plan.
+
+${LETSENCRYPT_ALTERNATIVE}`,
               },
               [ZEROSSL_ERRORS.CERTIFICATE_IS_NOT_VALIDATED]: {
                 description: chalk`ZeroSSL certificate is not approved.`,
@@ -121,11 +137,22 @@ and revoke the previous certificate in the ZeroSSL dashboard`,
               },
               [ZEROSSL_ERRORS.CERTIFICATE_IS_NOT_VALID]: {
                 description: chalk`ZeroSSL certificate is not valid.`,
-                solution: chalk`Please run {bold.cyanBright dashmate ssl zerossl obtain} to get a new one.`,
+                solution: chalk`Please run {bold.cyanBright dashmate ssl obtain} to get a new one.
+
+${LETSENCRYPT_ALTERNATIVE}`,
               },
               [ZEROSSL_ERRORS.ZERO_SSL_API_ERROR]: {
-                description: ssl?.data?.error?.message,
-                solution: chalk`Please contact ZeroSSL support if needed.`,
+                // ZeroSSL's own wording is the most accurate account of what went wrong - it
+                // names an exhausted certificate limit, an unpaid invoice or a rejected key
+                // directly. The fallback keeps the problem reported when it sends none, since
+                // an empty description would otherwise drop it silently.
+                description: ssl?.data?.error?.message
+                  ? chalk`ZeroSSL rejected the request: ${ssl.data.error.message}`
+                  : chalk`The ZeroSSL API could not be reached, so the certificate cannot be checked or renewed.`,
+                solution: chalk`If this is something you can resolve with ZeroSSL, such as an expired plan or a
+rejected API key, fix it there and run {bold.cyanBright dashmate ssl obtain}.
+
+${LETSENCRYPT_ALTERNATIVE}`,
               },
             };
 

--- a/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseConfigFactory.js
@@ -182,7 +182,7 @@ ${LETSENCRYPT_ALTERNATIVE}`,
                 description: chalk`A renewed Let's Encrypt certificate has not been installed for the gateway.`,
                 solution: chalk`The gateway keeps serving the previous certificate until it is reloaded,
 and will stop accepting clients when that one expires.
-Please restart the node: {bold.cyanBright dashmate restart}`,
+Please restart Platform: {bold.cyanBright dashmate restart --platform}`,
               },
               [LETSENCRYPT_ERRORS.CERTIFICATE_NOT_VALID]: {
                 description: chalk`Let's Encrypt certificate is not valid.`,

--- a/packages/dashmate/src/doctor/analyse/analyseGatewayCertificateFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseGatewayCertificateFactory.js
@@ -119,12 +119,13 @@ ${RESTART_HINT}`,
       ));
     }
 
-    // Both providers validate over inbound port 80. Being closed is only reported alongside a
-    // certificate problem: the port is bound just for the seconds a validation takes, so an
-    // external check finds it closed on healthy nodes too and on its own would be noise.
-    const acmeHttpPort = samples.getServiceInfo('gateway', 'acmeHttpPort');
+    // Both obtainable providers reach this node on port 80 to validate it. Being closed is
+    // only reported alongside a certificate problem: the port is bound just for the seconds a
+    // validation takes, so an external check finds it closed on healthy nodes too and on its
+    // own would be noise.
+    const validationHttpPort = samples.getServiceInfo('gateway', 'validationHttpPort');
 
-    if (problems.length > 0 && acmeHttpPort && acmeHttpPort !== 'OPEN') {
+    if (problems.length > 0 && validationHttpPort && validationHttpPort !== 'OPEN') {
       problems.push(new Problem(
         'Inbound port 80 is not reachable, which is how certificates are validated. '
         + 'This may be why renewal is failing',

--- a/packages/dashmate/src/doctor/analyse/analyseGatewayCertificateFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseGatewayCertificateFactory.js
@@ -7,7 +7,7 @@ import Problem from '../Problem.js';
  * operator following the advice can succeed and see no change on the wire. Every message about
  * a certificate the gateway has not picked up has to say this.
  */
-const RESTART_HINT = chalk`Then restart the node so the gateway picks it up: {bold.cyanBright dashmate restart}`;
+const RESTART_HINT = chalk`Then restart Platform so the gateway picks it up: {bold.cyanBright dashmate restart --platform}`;
 
 export default function analyseGatewayCertificateFactory() {
   /**
@@ -80,7 +80,7 @@ ${RESTART_HINT}`,
         `The gateway is serving a certificate that expired on ${served.certificate.validTo}, `
         + 'while a newer one is already present on disk',
         chalk`The certificate was renewed but never reached the gateway.
-{bold.cyanBright dashmate restart}`,
+{bold.cyanBright dashmate restart --platform}`,
         SEVERITY.HIGH,
       ));
     } else if (isServedExpired) {
@@ -100,7 +100,7 @@ ${RESTART_HINT}`,
         'The gateway is serving an older certificate than the one on disk. '
         + `It will stop accepting clients on ${served.certificate.validTo}`,
         chalk`The certificate was renewed but never reached the gateway.
-{bold.cyanBright dashmate restart}`,
+{bold.cyanBright dashmate restart --platform}`,
         SEVERITY.HIGH,
       ));
     }

--- a/packages/dashmate/src/doctor/analyse/analyseGatewayCertificateFactory.js
+++ b/packages/dashmate/src/doctor/analyse/analyseGatewayCertificateFactory.js
@@ -1,0 +1,142 @@
+import chalk from 'chalk';
+import { SEVERITY } from '../Prescription.js';
+import Problem from '../Problem.js';
+
+/**
+ * The manual obtain command writes certificate files but does not signal the gateway, so an
+ * operator following the advice can succeed and see no change on the wire. Every message about
+ * a certificate the gateway has not picked up has to say this.
+ */
+const RESTART_HINT = chalk`Then restart the node so the gateway picks it up: {bold.cyanBright dashmate restart}`;
+
+export default function analyseGatewayCertificateFactory() {
+  /**
+   * Analyse the certificate the gateway actually serves.
+   *
+   * @typedef analyseGatewayCertificate
+   * @param {Samples} samples
+   * @return {Problem[]}
+   */
+  function analyseGatewayCertificate(samples) {
+    const config = samples.getDashmateConfig();
+
+    if (!config?.get('platform.enable')) {
+      return [];
+    }
+
+    const served = samples.getServiceInfo('gateway', 'servedCertificate');
+
+    if (!served) {
+      return [];
+    }
+
+    const problems = [];
+
+    // Certificate validity is judged against the moment the samples were taken, not the moment
+    // they are analysed. A report is often opened days after it was collected, and the node's
+    // certificate may be renewed every few days, so judging at analysis time would report every
+    // healthy node as expired.
+    const now = samples.date?.getTime() ?? Date.now();
+
+    if (served.state === 'unreachable') {
+      problems.push(new Problem(
+        `The gateway did not answer a TLS connection (${served.reason}). Clients may not be able to connect`,
+        chalk`Please check that the gateway is running and listening: {bold.cyanBright dashmate status platform}`,
+        SEVERITY.MEDIUM,
+      ));
+
+      return problems;
+    }
+
+    if (served.state !== 'served') {
+      return problems;
+    }
+
+    const externalIp = config.get('externalIp');
+
+    // An identity mismatch is evaluated first and stops the comparisons below. It means the
+    // connection did not reach this node's gateway at all - another config or a proxy answering
+    // on the same port - and in that case the certificate it returned says nothing about this
+    // node, so reporting it as a wrong or stale certificate would be misleading.
+    if (served.identityVerified === false) {
+      problems.push(new Problem(
+        `The certificate served on port ${served.port} is not valid for ${externalIp}: ${served.identityError}`,
+        chalk`Either the certificate is issued for the wrong address, or something other than this
+node's gateway is answering on that port. Check that no other node or proxy is using it, then
+regenerate the certificate if needed: {bold.cyanBright dashmate ssl obtain --force}
+${RESTART_HINT}`,
+        SEVERITY.HIGH,
+      ));
+
+      return problems;
+    }
+
+    const servedExpiresAt = new Date(served.certificate.validTo).getTime();
+    const isServedExpired = servedExpiresAt <= now;
+    const onDiskDiffers = served.matchesOnDisk === false;
+
+    if (isServedExpired && onDiskDiffers) {
+      problems.push(new Problem(
+        `The gateway is serving a certificate that expired on ${served.certificate.validTo}, `
+        + 'while a newer one is already present on disk',
+        chalk`The certificate was renewed but never reached the gateway.
+{bold.cyanBright dashmate restart}`,
+        SEVERITY.HIGH,
+      ));
+    } else if (isServedExpired) {
+      problems.push(new Problem(
+        `The gateway is serving a certificate that expired on ${served.certificate.validTo}. `
+        + 'Clients cannot connect to this node',
+        chalk`Renewal has not succeeded. Check the renewal logs:
+{bold.cyanBright dashmate logs dashmate_helper}
+Then obtain a new certificate: {bold.cyanBright dashmate ssl obtain}
+${RESTART_HINT}`,
+        SEVERITY.HIGH,
+      ));
+    } else if (onDiskDiffers) {
+      // Still serving a valid certificate, but the renewed one has not been picked up, so this
+      // node goes dark when the served certificate expires.
+      problems.push(new Problem(
+        'The gateway is serving an older certificate than the one on disk. '
+        + `It will stop accepting clients on ${served.certificate.validTo}`,
+        chalk`The certificate was renewed but never reached the gateway.
+{bold.cyanBright dashmate restart}`,
+        SEVERITY.HIGH,
+      ));
+    }
+
+    // Reported separately from expiry because the connection surfaces only its first
+    // verification failure: a certificate that is both expired and untrusted reports only the
+    // expiry, and the second fault would otherwise stay hidden until the first was fixed.
+    if (!served.chainVerified && !isServedExpired) {
+      problems.push(new Problem(
+        `The certificate served by the gateway is not trusted by standard clients (${served.chainError})`,
+        chalk`Clients verifying against public certificate authorities will reject this node.
+If the certificate chain is incomplete, make sure the bundle contains the issuing
+certificates as well as the server certificate.
+${RESTART_HINT}`,
+        SEVERITY.HIGH,
+      ));
+    }
+
+    // Both providers validate over inbound port 80. Being closed is only reported alongside a
+    // certificate problem: the port is bound just for the seconds a validation takes, so an
+    // external check finds it closed on healthy nodes too and on its own would be noise.
+    const acmeHttpPort = samples.getServiceInfo('gateway', 'acmeHttpPort');
+
+    if (problems.length > 0 && acmeHttpPort && acmeHttpPort !== 'OPEN') {
+      problems.push(new Problem(
+        'Inbound port 80 is not reachable, which is how certificates are validated. '
+        + 'This may be why renewal is failing',
+        chalk`Please make sure port 80 on ${externalIp} accepts incoming connections from the
+internet. Both certificate providers connect back to it to validate this node's
+address before issuing a certificate. If you are behind NAT, forward port 80 as well.`,
+        SEVERITY.MEDIUM,
+      ));
+    }
+
+    return problems;
+  }
+
+  return analyseGatewayCertificate;
+}

--- a/packages/dashmate/src/doctor/analyseSamplesFactory.js
+++ b/packages/dashmate/src/doctor/analyseSamplesFactory.js
@@ -5,6 +5,7 @@ import Problem from './Problem.js';
  * @param {analyseSystemResources} analyseSystemResources
  * @param {analyseServiceContainers} analyseServiceContainers
  * @param {analyseConfig} analyseConfig
+ * @param {analyseGatewayCertificate} analyseGatewayCertificate
  * @param {analyseCore} analyseCore
  * @param {analysePlatform} analysePlatform
  * @return {analyseSamples}
@@ -13,6 +14,7 @@ export default function analyseSamplesFactory(
   analyseSystemResources,
   analyseServiceContainers,
   analyseConfig,
+  analyseGatewayCertificate,
   analyseCore,
   analysePlatform,
 ) {
@@ -40,6 +42,8 @@ export default function analyseSamplesFactory(
     problems.push(...analyseServiceContainers(samples));
 
     problems.push(...analyseConfig(samples));
+
+    problems.push(...analyseGatewayCertificate(samples));
 
     problems.push(...analyseCore(samples));
 

--- a/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
@@ -105,7 +105,10 @@ export default function collectSamplesTaskFactory(
                       const {
                         error,
                         data,
-                      } = validateZeroSslCertificate(config, Certificate.EXPIRATION_LIMIT_DAYS);
+                      } = await validateZeroSslCertificate(
+                        config,
+                        Certificate.EXPIRATION_LIMIT_DAYS,
+                      );
 
                       obfuscateObjectRecursive(data, (_field, value) => (typeof value === 'string' ? value.replaceAll(
                         process.env.USER,
@@ -311,7 +314,7 @@ export default function collectSamplesTaskFactory(
 
               const url = `http://${config.get('platform.drive.tenderdash.rpc.host')}:${config.get('platform.drive.tenderdash.rpc.port')}/metrics`;
 
-              const result = fetchTextOrError(url);
+              const result = await fetchTextOrError(url);
 
               ctx.samples.setServiceInfo('drive_tenderdash', 'metrics', result);
             }
@@ -322,7 +325,7 @@ export default function collectSamplesTaskFactory(
 
               const url = `http://${config.get('platform.drive.abci.metrics.host')}:${config.get('platform.drive.abci.metrics.port')}/metrics`;
 
-              const result = fetchTextOrError(url);
+              const result = await fetchTextOrError(url);
 
               ctx.samples.setServiceInfo('drive_abci', 'metrics', result);
             }
@@ -333,7 +336,7 @@ export default function collectSamplesTaskFactory(
 
               const url = `http://${config.get('platform.gateway.metrics.host')}:${config.get('platform.gateway.metrics.port')}/metrics`;
 
-              const result = fetchTextOrError(url);
+              const result = await fetchTextOrError(url);
 
               ctx.samples.setServiceInfo('gateway', 'metrics', result);
             }

--- a/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
@@ -233,23 +233,22 @@ export default function collectSamplesTaskFactory(
                       : null;
                   }
 
-                  obfuscateObjectRecursive(result, (_field, value) => (typeof value === 'string' ? value.replaceAll(
-                    process.env.USER,
-                    hideString(process.env.USER),
-                  ) : value));
-
                   ctx.samples.setServiceInfo('gateway', 'servedCertificate', result);
                 },
               },
               {
-                // Both certificate providers validate this node over inbound port 80.
-                enabled: () => config.get('platform.enable'),
-                title: 'ACME HTTP validation port',
+                // Both obtainable providers reach this node on port 80 to prove it controls
+                // its address before issuing: Let's Encrypt over ACME, ZeroSSL over its own
+                // verification server. A self-signed or operator-supplied certificate is
+                // never validated, so the port means nothing for those.
+                enabled: () => config.get('platform.enable')
+                  && ['zerossl', 'letsencrypt'].includes(config.get('platform.gateway.ssl.provider')),
+                title: 'Certificate validation port',
                 task: async () => {
                   const response = await providers.mnowatch.checkPortStatus(80, config.get('externalIp'))
                     .catch((e) => e.toString());
 
-                  ctx.samples.setServiceInfo('gateway', 'acmeHttpPort', response);
+                  ctx.samples.setServiceInfo('gateway', 'validationHttpPort', response);
                 },
               },
               {

--- a/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
@@ -39,7 +39,6 @@ async function fetchTextOrError(url) {
  * @param {HomeDir} homeDir
  * @param {validateZeroSslCertificate} validateZeroSslCertificate
  * @param {validateLetsEncryptCertificate} validateLetsEncryptCertificate
- * @param {boolean} isHelper
  * @return {collectSamplesTask}
  */
 export default function collectSamplesTaskFactory(
@@ -52,7 +51,6 @@ export default function collectSamplesTaskFactory(
   homeDir,
   validateZeroSslCertificate,
   validateLetsEncryptCertificate,
-  isHelper,
 ) {
   /**
    * @typedef {function} collectSamplesTask
@@ -198,36 +196,12 @@ export default function collectSamplesTaskFactory(
                 // Every other certificate check reads a file or the provider's API, so a
                 // certificate that was renewed on disk but never reached the gateway looks
                 // healthy to all of them. This connects to the gateway and records what it
-                // actually serves.
-                enabled: () => config.get('platform.enable'),
+                // actually serves. Doctor is run by an operator on the node, so the gateway's
+                // listener is reached at the address it is published on.
+                enabled: () => config.get('platform.enable')
+                  && config.get('platform.gateway.ssl.provider') !== 'self-signed',
                 title: 'Gateway served certificate',
                 task: async () => {
-                  // dashmate is installed in the helper image, so the CLI can be run there as
-                  // well as on the host. The gateway's listener is published to the host, and
-                  // inside the helper the same address is that container's own, so probing it
-                  // would report a healthy gateway as unreachable. Recorded rather than
-                  // silently dropped, so it reads as unknown instead of as a healthy node.
-                  if (isHelper) {
-                    ctx.samples.setServiceInfo('gateway', 'servedCertificate', {
-                      state: PROBE_STATE.SKIPPED,
-                      reason: 'helper-context',
-                    });
-
-                    return;
-                  }
-
-                  // A self-signed certificate is not trusted by design, so what it serves says
-                  // nothing a check could act on. It is already reported by the configuration
-                  // analysis when it is used on a network where it does not belong.
-                  if (config.get('platform.gateway.ssl.provider') === 'self-signed') {
-                    ctx.samples.setServiceInfo('gateway', 'servedCertificate', {
-                      state: PROBE_STATE.SKIPPED,
-                      reason: 'self-signed',
-                    });
-
-                    return;
-                  }
-
                   const listenerHost = config.get('platform.gateway.listeners.dapiAndDrive.host');
                   const port = config.get('platform.gateway.listeners.dapiAndDrive.port');
 

--- a/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
@@ -39,6 +39,7 @@ async function fetchTextOrError(url) {
  * @param {HomeDir} homeDir
  * @param {validateZeroSslCertificate} validateZeroSslCertificate
  * @param {validateLetsEncryptCertificate} validateLetsEncryptCertificate
+ * @param {boolean} isHelper
  * @return {collectSamplesTask}
  */
 export default function collectSamplesTaskFactory(
@@ -51,6 +52,7 @@ export default function collectSamplesTaskFactory(
   homeDir,
   validateZeroSslCertificate,
   validateLetsEncryptCertificate,
+  isHelper,
 ) {
   /**
    * @typedef {function} collectSamplesTask
@@ -196,12 +198,36 @@ export default function collectSamplesTaskFactory(
                 // Every other certificate check reads a file or the provider's API, so a
                 // certificate that was renewed on disk but never reached the gateway looks
                 // healthy to all of them. This connects to the gateway and records what it
-                // actually serves. Doctor only ever runs from the CLI - the helper exposes
-                // status and nothing else - so the listener is reached on its published port.
-                enabled: () => config.get('platform.enable')
-                  && config.get('platform.gateway.ssl.provider') !== 'self-signed',
+                // actually serves.
+                enabled: () => config.get('platform.enable'),
                 title: 'Gateway served certificate',
                 task: async () => {
+                  // dashmate is installed in the helper image, so the CLI can be run there as
+                  // well as on the host. The gateway's listener is published to the host, and
+                  // inside the helper the same address is that container's own, so probing it
+                  // would report a healthy gateway as unreachable. Recorded rather than
+                  // silently dropped, so it reads as unknown instead of as a healthy node.
+                  if (isHelper) {
+                    ctx.samples.setServiceInfo('gateway', 'servedCertificate', {
+                      state: PROBE_STATE.SKIPPED,
+                      reason: 'helper-context',
+                    });
+
+                    return;
+                  }
+
+                  // A self-signed certificate is not trusted by design, so what it serves says
+                  // nothing a check could act on. It is already reported by the configuration
+                  // analysis when it is used on a network where it does not belong.
+                  if (config.get('platform.gateway.ssl.provider') === 'self-signed') {
+                    ctx.samples.setServiceInfo('gateway', 'servedCertificate', {
+                      state: PROBE_STATE.SKIPPED,
+                      reason: 'self-signed',
+                    });
+
+                    return;
+                  }
+
                   const listenerHost = config.get('platform.gateway.listeners.dapiAndDrive.host');
                   const port = config.get('platform.gateway.listeners.dapiAndDrive.port');
 

--- a/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
@@ -7,6 +7,8 @@ import obfuscateConfig from '../../../config/obfuscateConfig.js';
 import { DASHMATE_VERSION } from '../../../constants.js';
 import LegoCertificate from '../../../ssl/letsencrypt/LegoCertificate.js';
 import Certificate from '../../../ssl/zerossl/Certificate.js';
+import probeServedCertificate, { STATE as PROBE_STATE } from '../../../ssl/probeServedCertificate.js';
+import readCertificateBundle from '../../../ssl/readCertificateBundle.js';
 import providers from '../../../status/providers.js';
 import hideString from '../../../util/hideString.js';
 import obfuscateObjectRecursive from '../../../util/obfuscateObjectRecursive.js';
@@ -188,6 +190,66 @@ export default function collectSamplesTaskFactory(
                     default:
                       throw new Error('Unknown SSL provider');
                   }
+                },
+              },
+              {
+                // Every other certificate check reads a file or the provider's API, so a
+                // certificate that was renewed on disk but never reached the gateway looks
+                // healthy to all of them. This connects to the gateway and records what it
+                // actually serves. Doctor only ever runs from the CLI - the helper exposes
+                // status and nothing else - so the listener is reached on its published port.
+                enabled: () => config.get('platform.enable')
+                  && config.get('platform.gateway.ssl.provider') !== 'self-signed',
+                title: 'Gateway served certificate',
+                task: async () => {
+                  const listenerHost = config.get('platform.gateway.listeners.dapiAndDrive.host');
+                  const port = config.get('platform.gateway.listeners.dapiAndDrive.port');
+
+                  const result = await probeServedCertificate({
+                    host: listenerHost === '0.0.0.0' ? '127.0.0.1' : listenerHost,
+                    port,
+                    externalIp: config.get('externalIp'),
+                  });
+
+                  result.port = port;
+
+                  if (result.state === PROBE_STATE.SERVED) {
+                    // Read beside the probe rather than at analysis time: renewal replaces the
+                    // file and signals the gateway moments apart, and the rest of the sample
+                    // collection takes long enough that the two would routinely be read from
+                    // either side of a renewal and reported as a mismatch.
+                    const onDisk = readCertificateBundle(path.join(
+                      homeDir.joinPath(config.getName(), 'platform', 'gateway', 'ssl'),
+                      'bundle.crt',
+                    ));
+
+                    result.onDisk = onDisk && {
+                      fingerprint256: onDisk.fingerprint256,
+                      validTo: onDisk.validTo.toUTCString(),
+                    };
+
+                    result.matchesOnDisk = onDisk
+                      ? onDisk.fingerprint256 === result.certificate.fingerprint256
+                      : null;
+                  }
+
+                  obfuscateObjectRecursive(result, (_field, value) => (typeof value === 'string' ? value.replaceAll(
+                    process.env.USER,
+                    hideString(process.env.USER),
+                  ) : value));
+
+                  ctx.samples.setServiceInfo('gateway', 'servedCertificate', result);
+                },
+              },
+              {
+                // Both certificate providers validate this node over inbound port 80.
+                enabled: () => config.get('platform.enable'),
+                title: 'ACME HTTP validation port',
+                task: async () => {
+                  const response = await providers.mnowatch.checkPortStatus(80, config.get('externalIp'))
+                    .catch((e) => e.toString());
+
+                  ctx.samples.setServiceInfo('gateway', 'acmeHttpPort', response);
                 },
               },
               {

--- a/packages/dashmate/src/ssl/letsencrypt/validateLetsEncryptCertificateFactory.js
+++ b/packages/dashmate/src/ssl/letsencrypt/validateLetsEncryptCertificateFactory.js
@@ -12,6 +12,7 @@ export const ERRORS = {
   CERTIFICATE_EXPIRES_SOON: 'CERTIFICATE_EXPIRES_SOON',
   CERTIFICATE_IP_MISMATCH: 'CERTIFICATE_IP_MISMATCH',
   CERTIFICATE_NOT_VALID: 'CERTIFICATE_NOT_VALID',
+  CERTIFICATE_NOT_INSTALLED: 'CERTIFICATE_NOT_INSTALLED',
 };
 
 /**
@@ -129,6 +130,16 @@ export default function validateLetsEncryptCertificateFactory(homeDir) {
     if (data.isExpiresSoon) {
       return {
         error: ERRORS.CERTIFICATE_EXPIRES_SOON,
+        data,
+      };
+    }
+
+    // The certificate is valid, but the gateway loads its own copy rather than the issued
+    // file. Until the two match the node keeps serving whatever was installed last, which
+    // stays invisible to every check that only looks at the issued certificate.
+    if (!data.isCertificatePairInstalled) {
+      return {
+        error: ERRORS.CERTIFICATE_NOT_INSTALLED,
         data,
       };
     }

--- a/packages/dashmate/src/ssl/probeServedCertificate.js
+++ b/packages/dashmate/src/ssl/probeServedCertificate.js
@@ -1,0 +1,155 @@
+import tls from 'node:tls';
+
+/**
+ * How long the whole probe may take, matching the timeout used for the port checks.
+ *
+ * This is an absolute budget covering the TCP connect and the TLS handshake together. The
+ * socket's own timeout option cannot serve as one: it is an inactivity timer that resets on
+ * every byte received and does not close the socket, so a peer trickling data keeps a probe
+ * alive indefinitely.
+ */
+export const PROBE_TIMEOUT_MS = 5000;
+
+export const STATE = {
+  SERVED: 'served',
+  UNREACHABLE: 'unreachable',
+  SKIPPED: 'skipped',
+};
+
+/**
+ * Flatten a TLS peer certificate into plain values.
+ *
+ * The peer certificate must never be stored as it is: a chain that verifies ends at a
+ * self-signed root whose issuerCertificate points back at itself, and that cycle makes both
+ * JSON serialisation and the sample obfuscation pass fail. Its raw and pubkey fields are also
+ * buffers that serialise into thousands of numbers.
+ *
+ * @param {Object} peerCertificate
+ * @return {Object}
+ */
+function flattenCertificate(peerCertificate) {
+  return {
+    fingerprint256: peerCertificate.fingerprint256,
+    validFrom: peerCertificate.valid_from,
+    validTo: peerCertificate.valid_to,
+    subject: peerCertificate.subject?.CN ?? null,
+    issuer: peerCertificate.issuer?.CN ?? null,
+    subjectAltName: peerCertificate.subjectaltname ?? null,
+    serialNumber: peerCertificate.serialNumber ?? null,
+  };
+}
+
+/**
+ * Connect to the gateway and report the certificate it actually serves.
+ *
+ * Every other certificate check reads a file or asks the provider's API. A certificate that was
+ * renewed on disk but never reached the gateway is indistinguishable from a healthy one to all
+ * of them, so this opens a real connection and looks at what the gateway presents.
+ *
+ * @param {Object} options
+ * @param {string} options.host - address the gateway listener is reachable on
+ * @param {number} options.port
+ * @param {string} options.externalIp - the address clients use, which the certificate must name
+ * @param {number} [options.timeout]
+ * @return {Promise<Object>} never rejects
+ */
+export default async function probeServedCertificate({
+  host,
+  port,
+  externalIp,
+  timeout = PROBE_TIMEOUT_MS,
+}) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let deadline;
+
+    const settle = (result) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+
+      clearTimeout(deadline);
+
+      resolve(result);
+    };
+
+    let socket;
+
+    const fail = (reason) => {
+      socket?.destroy();
+
+      settle({
+        state: STATE.UNREACHABLE,
+        reason,
+      });
+    };
+
+    deadline = setTimeout(() => fail('ETIMEDOUT'), timeout);
+
+    try {
+      socket = tls.connect({
+        host,
+        port,
+        // A certificate identifying a node by IP address cannot be requested by name: SNI must
+        // not carry an IP literal, and the gateway selects its filter chain without it.
+        servername: undefined,
+        // The handshake has to complete even when the certificate is expired or untrusted,
+        // otherwise the probe learns nothing in the cases it exists for. Verification still
+        // runs and its verdict is read from the socket below. Nothing here grants trust: the
+        // result is reported, never used to authorise a connection.
+        rejectUnauthorized: false,
+        // Node would otherwise check the certificate against the address being dialled, which
+        // is the local address the gateway happens to be reachable on rather than the one
+        // clients use, and a correct certificate would fail that on every healthy node. The
+        // check is done separately below, against the address that matters.
+        checkServerIdentity: () => undefined,
+      });
+    } catch (e) {
+      fail(e.code ?? 'CONNECT_FAILED');
+
+      return;
+    }
+
+    // Stays attached for the socket's lifetime. A connection can fail after the certificate has
+    // already been read, and settle() ignores anything that arrives once a result is decided.
+    socket.on('error', (e) => fail(e.code ?? 'CONNECT_FAILED'));
+
+    socket.on('timeout', () => fail('ETIMEDOUT'));
+
+    socket.on('secureConnect', () => {
+      const peerCertificate = socket.getPeerCertificate(true);
+
+      // An absent peer certificate is reported as an empty object, which would otherwise be
+      // taken for a served certificate with no fields and compared against the one on disk.
+      if (!peerCertificate?.fingerprint256) {
+        fail('NO_PEER_CERTIFICATE');
+
+        return;
+      }
+
+      const { authorized, authorizationError } = socket;
+
+      // Identity is checked separately from the chain because the socket reports only one
+      // error: an expired certificate that also names the wrong address reports just the
+      // expiry, so a single verdict would hide the second fault until the first was fixed.
+      // Delegating to Node handles the common-name fallback and address normalisation that a
+      // hand-rolled comparison against the alternative names gets wrong.
+      const identityError = externalIp
+        ? tls.checkServerIdentity(externalIp, peerCertificate)
+        : undefined;
+
+      socket.destroy();
+
+      settle({
+        state: STATE.SERVED,
+        certificate: flattenCertificate(peerCertificate),
+        chainVerified: authorized,
+        chainError: authorized ? null : (authorizationError?.code ?? String(authorizationError)),
+        identityVerified: externalIp ? identityError === undefined : null,
+        identityError: identityError ? identityError.message : null,
+      });
+    });
+  });
+}

--- a/packages/dashmate/src/ssl/readCertificateBundle.js
+++ b/packages/dashmate/src/ssl/readCertificateBundle.js
@@ -1,0 +1,76 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+
+/**
+ * Extract IP addresses from the OpenSSL rendering of a subject alternative name extension.
+ *
+ * The value is a single string such as "IP Address:1.2.3.4, DNS:example.com", so entries are
+ * split out rather than substring-matched: searching the raw string for "1.2.3.4" would also
+ * match inside "11.2.3.44" and inside a DNS entry.
+ *
+ * @param {string|undefined} subjectAltName
+ * @return {string[]}
+ */
+function parseIpAddresses(subjectAltName) {
+  if (!subjectAltName) {
+    return [];
+  }
+
+  return subjectAltName
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.startsWith('IP Address:'))
+    .map((entry) => entry.slice('IP Address:'.length));
+}
+
+/**
+ * Read the server certificate from a PEM bundle.
+ *
+ * The server certificate is expected first, but an operator supplying their own bundle can
+ * order it the other way round, so the first block is only accepted when it is not a CA.
+ * Comparing a served certificate against an intermediate would report a permanent mismatch.
+ *
+ * The fingerprint is the same uppercase colon-separated SHA-256 that a TLS peer certificate
+ * reports, so the two can be compared directly.
+ *
+ * @param {string} filePath
+ * @return {{fingerprint256: string, validFrom: Date, validTo: Date, subject: string,
+ *   issuer: string, ipAddresses: string[]}|null} null when the file is missing or unparseable
+ */
+export default function readCertificateBundle(filePath) {
+  let pem;
+
+  try {
+    pem = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  const blocks = pem.match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g) ?? [];
+
+  for (const block of blocks) {
+    let certificate;
+
+    try {
+      certificate = new crypto.X509Certificate(block);
+    } catch {
+      // Skip a block we cannot parse rather than failing the whole bundle
+      continue;
+    }
+
+    if (certificate.ca) {
+      continue;
+    }
+
+    return {
+      fingerprint256: certificate.fingerprint256,
+      validFrom: new Date(certificate.validFrom),
+      validTo: new Date(certificate.validTo),
+      subject: certificate.subject,
+      issuer: certificate.issuer,
+      ipAddresses: parseIpAddresses(certificate.subjectAltName),
+    };
+  }
+
+  return null;
+}

--- a/packages/dashmate/src/test/createCertificateForTest.js
+++ b/packages/dashmate/src/test/createCertificateForTest.js
@@ -1,0 +1,45 @@
+import forge from 'node-forge';
+
+/**
+ * Create a self-signed certificate with a chosen validity window and IP address.
+ *
+ * Certificates are generated when a test runs rather than committed, so a fixture cannot
+ * expire and fail the suite on a date nobody chose. Built with node-forge rather than the
+ * openssl binary because the flags needed to place a certificate in the past arrived in
+ * OpenSSL 3.5, which is newer than the version on the CI image.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.ip] - placed in the subject alternative name and common name
+ * @param {number} [options.days] - days from now the certificate expires, negative for expired
+ * @return {{cert: string, key: string}} PEM encoded
+ */
+export default function createCertificateForTest({ ip = '127.0.0.1', days = 30 } = {}) {
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const certificate = forge.pki.createCertificate();
+
+  certificate.publicKey = keys.publicKey;
+  certificate.serialNumber = '01';
+
+  // Anchored to the expiry so an already-expired certificate still starts before it ends
+  certificate.validity.notAfter = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+  certificate.validity.notBefore = new Date(
+    certificate.validity.notAfter.getTime() - 30 * 24 * 60 * 60 * 1000,
+  );
+
+  const attributes = [{ name: 'commonName', value: ip }];
+
+  certificate.setSubject(attributes);
+  certificate.setIssuer(attributes);
+  certificate.setExtensions([
+    { name: 'basicConstraints', cA: false },
+    // Type 7 is an IP address. An evonode is identified by its address, not by a name.
+    { name: 'subjectAltName', altNames: [{ type: 7, ip }] },
+  ]);
+
+  certificate.sign(keys.privateKey, forge.md.sha256.create());
+
+  return {
+    cert: forge.pki.certificateToPem(certificate),
+    key: forge.pki.privateKeyToPem(keys.privateKey),
+  };
+}

--- a/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
+++ b/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
@@ -1,5 +1,6 @@
 import { Listr } from 'listr2';
 import ObtainCommand from '../../../../src/commands/ssl/obtain.js';
+import ServiceIsNotRunningError from '../../../../src/docker/errors/ServiceIsNotRunningError.js';
 
 describe('SSL obtain command', () => {
   it('should reload the gateway so the new certificate is served', async function it() {
@@ -34,13 +35,13 @@ describe('SSL obtain command', () => {
     expect(dockerCompose.execCommand).to.have.been.calledOnceWith(config, 'gateway', 'kill -SIGHUP 1');
   });
 
-  it('should not fail when the gateway is not running yet', async function it() {
+  it('should not fail when the gateway stops before it can be signalled', async function it() {
     const config = {
       get: this.sinon.stub().callsFake((option) => (option === 'platform.enable' ? true : 'letsencrypt')),
     };
     const dockerCompose = {
-      isServiceRunning: this.sinon.stub().resolves(false),
-      execCommand: this.sinon.stub().resolves(),
+      isServiceRunning: this.sinon.stub().resolves(true),
+      execCommand: this.sinon.stub().rejects(new ServiceIsNotRunningError('testnet', 'gateway')),
     };
 
     await new ObtainCommand().runWithDependencies(
@@ -60,7 +61,7 @@ describe('SSL obtain command', () => {
       dockerCompose,
     );
 
-    expect(dockerCompose.execCommand).to.have.not.been.called();
+    expect(dockerCompose.execCommand).to.have.been.calledOnce();
   });
 
   it('should checkpoint a newly created ZeroSSL certificate before a later failure', async function it() {

--- a/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
+++ b/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
@@ -2,6 +2,67 @@ import { Listr } from 'listr2';
 import ObtainCommand from '../../../../src/commands/ssl/obtain.js';
 
 describe('SSL obtain command', () => {
+  it('should reload the gateway so the new certificate is served', async function it() {
+    // Writing the certificate files is not enough: the gateway keeps serving the previous
+    // certificate until it is signalled, so an operator can run this command, see it succeed,
+    // and find nothing changed on the wire.
+    const config = {
+      get: this.sinon.stub().callsFake((option) => (option === 'platform.enable' ? true : 'letsencrypt')),
+    };
+    const dockerCompose = {
+      isServiceRunning: this.sinon.stub().resolves(true),
+      execCommand: this.sinon.stub().resolves(),
+    };
+
+    await new ObtainCommand().runWithDependencies(
+      {},
+      {
+        verbose: false,
+        'no-retry': true,
+        'expiration-days': undefined,
+        force: false,
+        provider: 'letsencrypt',
+      },
+      config,
+      this.sinon.stub(),
+      this.sinon.stub().returns(new Listr([{ task: () => {} }])),
+      { write: this.sinon.stub() },
+      {},
+      dockerCompose,
+    );
+
+    expect(dockerCompose.execCommand).to.have.been.calledOnceWith(config, 'gateway', 'kill -SIGHUP 1');
+  });
+
+  it('should not fail when the gateway is not running yet', async function it() {
+    const config = {
+      get: this.sinon.stub().callsFake((option) => (option === 'platform.enable' ? true : 'letsencrypt')),
+    };
+    const dockerCompose = {
+      isServiceRunning: this.sinon.stub().resolves(false),
+      execCommand: this.sinon.stub().resolves(),
+    };
+
+    await new ObtainCommand().runWithDependencies(
+      {},
+      {
+        verbose: false,
+        'no-retry': true,
+        'expiration-days': undefined,
+        force: false,
+        provider: 'letsencrypt',
+      },
+      config,
+      this.sinon.stub(),
+      this.sinon.stub().returns(new Listr([{ task: () => {} }])),
+      { write: this.sinon.stub() },
+      {},
+      dockerCompose,
+    );
+
+    expect(dockerCompose.execCommand).to.have.not.been.called();
+  });
+
   it('should checkpoint a newly created ZeroSSL certificate before a later failure', async function it() {
     const config = {
       get: this.sinon.stub().returns('zerossl'),
@@ -34,6 +95,7 @@ describe('SSL obtain command', () => {
       this.sinon.stub(),
       configFileRepository,
       configFile,
+      { isServiceRunning: this.sinon.stub().resolves(false), execCommand: this.sinon.stub() },
     )).to.be.rejected();
 
     expect(obtainZeroSSLCertificateTask).to.have.been.calledOnce();

--- a/packages/dashmate/test/unit/doctor/analyse/analyseConfigFactory.spec.js
+++ b/packages/dashmate/test/unit/doctor/analyse/analyseConfigFactory.spec.js
@@ -96,6 +96,58 @@ describe('analyseConfigFactory', () => {
     expect(problems[0].getDescription()).to.include('SSL certificate files are not found');
   });
 
+  describe('ZeroSSL remediation', () => {
+    it('should offer both renewing with ZeroSSL and switching to Let\'s Encrypt', () => {
+      // Whether renewing works depends on the operator's ZeroSSL plan, which dashmate cannot
+      // see, so both routes are offered rather than one being asserted to be the answer.
+      const [problem] = analyseSslSample({
+        error: ZEROSSL_ERRORS.CERTIFICATE_EXPIRES_SOON,
+        data: { certificate: { expires: '2026-01-01' } },
+      });
+
+      expect(problem.getSolution()).to.include('dashmate ssl obtain');
+      expect(problem.getSolution()).to.include('platform.gateway.ssl.provider letsencrypt');
+    });
+
+    it('should state the cost of switching so the choice is informed', () => {
+      const [problem] = analyseSslSample({
+        error: ZEROSSL_ERRORS.CERTIFICATE_EXPIRES_SOON,
+        data: { certificate: { expires: '2026-01-01' } },
+      });
+
+      expect(problem.getSolution()).to.include('6 days');
+    });
+
+    it('should surface the reason ZeroSSL itself gave', () => {
+      const [problem] = analyseSslSample({
+        error: ZEROSSL_ERRORS.ZERO_SSL_API_ERROR,
+        data: { error: { message: 'Limit of certificates on your ZeroSSL account was reached' } },
+      });
+
+      expect(problem.getDescription()).to.include('Limit of certificates');
+      expect(problem.getSolution()).to.include('platform.gateway.ssl.provider letsencrypt');
+    });
+
+    it('should still report an API failure that carried no message', () => {
+      // The description doubles as the presence check, so an empty one dropped the problem
+      const problems = analyseSslSample({
+        error: ZEROSSL_ERRORS.ZERO_SSL_API_ERROR,
+        data: {},
+      });
+
+      expect(problems).to.have.lengthOf(1);
+    });
+
+    it('should not suggest a command that does not exist', () => {
+      const [problem] = analyseSslSample({
+        error: ZEROSSL_ERRORS.CERTIFICATE_IS_NOT_VALID,
+        data: {},
+      });
+
+      expect(problem.getSolution()).to.not.include('ssl zerossl obtain');
+    });
+  });
+
   it('should not report a problem for a valid certificate', () => {
     const problems = analyseSslSample({ data: {} });
 

--- a/packages/dashmate/test/unit/doctor/analyse/analyseConfigFactory.spec.js
+++ b/packages/dashmate/test/unit/doctor/analyse/analyseConfigFactory.spec.js
@@ -1,0 +1,104 @@
+import getBaseConfigFactory from '../../../../configs/defaults/getBaseConfigFactory.js';
+import analyseConfigFactory from '../../../../src/doctor/analyse/analyseConfigFactory.js';
+import { SEVERITY } from '../../../../src/doctor/Prescription.js';
+import Samples from '../../../../src/doctor/Samples.js';
+import { ERRORS as LETSENCRYPT_ERRORS } from '../../../../src/ssl/letsencrypt/validateLetsEncryptCertificateFactory.js';
+import { ERRORS as ZEROSSL_ERRORS } from '../../../../src/ssl/zerossl/validateZeroSslCertificateFactory.js';
+
+describe('analyseConfigFactory', () => {
+  let analyseConfig;
+  let config;
+  let samples;
+
+  /**
+   * @param {Object} ssl
+   * @param {string} [provider=zerossl]
+   * @return {Problem[]}
+   */
+  function analyseSslSample(ssl, provider = 'zerossl') {
+    config.set('platform.gateway.ssl.provider', provider);
+
+    samples.setServiceInfo('gateway', 'ssl', ssl);
+
+    return analyseConfig(samples);
+  }
+
+  beforeEach(() => {
+    config = getBaseConfigFactory()();
+
+    config.set('platform.enable', true);
+
+    samples = new Samples();
+    samples.setDashmateConfig(config);
+
+    // Ports are reported healthy so that only certificate problems are analysed
+    samples.setServiceInfo('core', 'p2pPort', 'OPEN');
+    samples.setServiceInfo('gateway', 'httpPort', 'OPEN');
+    samples.setServiceInfo('drive_tenderdash', 'p2pPort', 'OPEN');
+
+    analyseConfig = analyseConfigFactory();
+  });
+
+  it('should report a problem for a Let\'s Encrypt certificate that expires soon', () => {
+    const problems = analyseSslSample({
+      error: LETSENCRYPT_ERRORS.CERTIFICATE_EXPIRES_SOON,
+      data: { certificate: { expires: '2026-01-01' } },
+    }, 'letsencrypt');
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('Let\'s Encrypt certificate expires at');
+    expect(problems[0].getSeverity()).to.equal(SEVERITY.HIGH);
+  });
+
+  it('should report a problem for a ZeroSSL certificate that expires soon', () => {
+    const problems = analyseSslSample({
+      error: ZEROSSL_ERRORS.CERTIFICATE_EXPIRES_SOON,
+      data: { certificate: { expires: '2026-01-01' } },
+    });
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('ZeroSSL certificate expires at');
+    expect(problems[0].getSeverity()).to.equal(SEVERITY.HIGH);
+  });
+
+  it('should report a problem when the ZeroSSL API key is not set', () => {
+    const problems = analyseSslSample({
+      error: ZEROSSL_ERRORS.API_KEY_IS_NOT_SET,
+      data: {},
+    });
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('ZeroSSL API key is not set');
+    expect(problems[0].getSolution()).to.include('dashmate config set platform.gateway.ssl.providerConfigs.zerossl.apiKey');
+  });
+
+  it('should report a problem when the external IP is not set', () => {
+    const problems = analyseSslSample({
+      error: ZEROSSL_ERRORS.EXTERNAL_IP_IS_NOT_SET,
+      data: {},
+    });
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('External IP is not set');
+    expect(problems[0].getSolution()).to.include('dashmate config set externalIp');
+  });
+
+  it('should report a problem when certificate files are not found', () => {
+    const problems = analyseSslSample({
+      error: 'not-exist',
+      data: {
+        chainFilePath: '/home/dashmate/ssl/bundle.crt',
+        privateFilePath: '/home/dashmate/ssl/private.key',
+      },
+    }, 'file');
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('SSL certificate files are not found');
+  });
+
+  it('should not report a problem for a valid certificate', () => {
+    const problems = analyseSslSample({ data: {} });
+
+    expect(problems).to.be.empty();
+  });
+});

--- a/packages/dashmate/test/unit/doctor/analyse/analyseConfigFactory.spec.js
+++ b/packages/dashmate/test/unit/doctor/analyse/analyseConfigFactory.spec.js
@@ -109,13 +109,14 @@ describe('analyseConfigFactory', () => {
       expect(problem.getSolution()).to.include('platform.gateway.ssl.provider letsencrypt');
     });
 
-    it('should state the cost of switching so the choice is informed', () => {
+    it('should name what makes the alternative worth taking', () => {
+      // Both providers renew on their own, so that is not what separates them
       const [problem] = analyseSslSample({
         error: ZEROSSL_ERRORS.CERTIFICATE_EXPIRES_SOON,
         data: { certificate: { expires: '2026-01-01' } },
       });
 
-      expect(problem.getSolution()).to.include('6 days');
+      expect(problem.getSolution()).to.include('free');
     });
 
     it('should surface the reason ZeroSSL itself gave', () => {

--- a/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
@@ -1,0 +1,167 @@
+import getBaseConfigFactory from '../../../../configs/defaults/getBaseConfigFactory.js';
+import analyseGatewayCertificateFactory from '../../../../src/doctor/analyse/analyseGatewayCertificateFactory.js';
+import { SEVERITY } from '../../../../src/doctor/Prescription.js';
+import Samples from '../../../../src/doctor/Samples.js';
+
+const EXTERNAL_IP = '198.51.100.7';
+
+/**
+ * @param {number} days - relative to now, negative for an expired certificate
+ * @return {string}
+ */
+function validTo(days) {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toUTCString();
+}
+
+describe('analyseGatewayCertificateFactory', () => {
+  let analyseGatewayCertificate;
+  let config;
+  let samples;
+
+  /**
+   * @param {Object} servedCertificate
+   * @return {Problem[]}
+   */
+  function analyse(servedCertificate) {
+    samples.setServiceInfo('gateway', 'servedCertificate', servedCertificate);
+
+    return analyseGatewayCertificate(samples);
+  }
+
+  /**
+   * @param {Object} overrides
+   * @return {Object}
+   */
+  function served(overrides = {}) {
+    return {
+      state: 'served',
+      port: 443,
+      certificate: { fingerprint256: 'AA:BB', validTo: validTo(30) },
+      chainVerified: true,
+      chainError: null,
+      identityVerified: true,
+      identityError: null,
+      matchesOnDisk: true,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    config = getBaseConfigFactory()();
+
+    config.set('platform.enable', true);
+    config.set('externalIp', EXTERNAL_IP);
+
+    samples = new Samples();
+    samples.setDashmateConfig(config);
+
+    analyseGatewayCertificate = analyseGatewayCertificateFactory();
+  });
+
+  it('should report no problem for a healthy certificate', () => {
+    expect(analyse(served())).to.be.empty();
+  });
+
+  it('should report an expired certificate that clients cannot connect to', () => {
+    const problems = analyse(served({
+      certificate: { fingerprint256: 'AA:BB', validTo: validTo(-158) },
+    }));
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('expired');
+    expect(problems[0].getSeverity()).to.equal(SEVERITY.HIGH);
+    expect(problems[0].getSolution()).to.include('dashmate_helper');
+  });
+
+  it('should distinguish a certificate that was renewed but never reached the gateway', () => {
+    const problems = analyse(served({
+      certificate: { fingerprint256: 'AA:BB', validTo: validTo(-2) },
+      matchesOnDisk: false,
+    }));
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('newer one is already present on disk');
+    expect(problems[0].getSolution()).to.include('dashmate restart');
+  });
+
+  it('should warn before the outage when a renewed certificate has not been picked up', () => {
+    const problems = analyse(served({ matchesOnDisk: false }));
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('older certificate than the one on disk');
+    expect(problems[0].getSeverity()).to.equal(SEVERITY.HIGH);
+  });
+
+  it('should report an untrusted certificate separately from expiry', () => {
+    const problems = analyse(served({
+      chainVerified: false,
+      chainError: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    }));
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('not trusted by standard clients');
+  });
+
+  it('should treat an identity mismatch as not having reached this node and stop there', () => {
+    // A different node or a proxy answering on the port returns a certificate that says nothing
+    // about this node, so reporting it as stale or expired would send the operator the wrong way.
+    const problems = analyse(served({
+      identityVerified: false,
+      identityError: 'Host: 198.51.100.7 is not in the cert\'s altnames',
+      matchesOnDisk: false,
+      certificate: { fingerprint256: 'CC:DD', validTo: validTo(-10) },
+    }));
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('not valid for 198.51.100.7');
+  });
+
+  it('should judge expiry against the time the samples were taken, not the time of analysis', () => {
+    // Reports are commonly opened days after collection, and a Let's Encrypt certificate for an
+    // IP address lives about six days, so judging at analysis time reports healthy nodes as dead.
+    samples.date = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+
+    const problems = analyse(served({
+      certificate: { fingerprint256: 'AA:BB', validTo: validTo(-4) },
+    }));
+
+    expect(problems).to.be.empty();
+  });
+
+  it('should report a closed port 80 as a likely cause when a certificate problem exists', () => {
+    samples.setServiceInfo('gateway', 'acmeHttpPort', 'CLOSED');
+
+    const problems = analyse(served({
+      certificate: { fingerprint256: 'AA:BB', validTo: validTo(-3) },
+    }));
+
+    expect(problems).to.have.lengthOf(2);
+    expect(problems[1].getDescription()).to.include('port 80');
+  });
+
+  it('should not report a closed port 80 on a node whose certificate is healthy', () => {
+    // The port is only bound for the seconds a validation takes, so an external check finds it
+    // closed on actively renewing nodes too. Alone it would fire far more often than it is right.
+    samples.setServiceInfo('gateway', 'acmeHttpPort', 'CLOSED');
+
+    expect(analyse(served())).to.be.empty();
+  });
+
+  it('should report a gateway that does not answer TLS', () => {
+    const problems = analyse({ state: 'unreachable', reason: 'ECONNREFUSED' });
+
+    expect(problems).to.have.lengthOf(1);
+    expect(problems[0].getDescription()).to.include('did not answer');
+    expect(problems[0].getSeverity()).to.equal(SEVERITY.MEDIUM);
+  });
+
+  it('should report nothing when the probe was skipped', () => {
+    expect(analyse({ state: 'skipped', reason: 'self-signed' })).to.be.empty();
+  });
+
+  it('should report nothing when platform is disabled', () => {
+    config.set('platform.enable', false);
+
+    expect(analyse(served({ certificate: { validTo: validTo(-100) } }))).to.be.empty();
+  });
+});

--- a/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
@@ -129,7 +129,7 @@ describe('analyseGatewayCertificateFactory', () => {
   });
 
   it('should report a closed port 80 as a likely cause when a certificate problem exists', () => {
-    samples.setServiceInfo('gateway', 'acmeHttpPort', 'CLOSED');
+    samples.setServiceInfo('gateway', 'validationHttpPort', 'CLOSED');
 
     const problems = analyse(served({
       certificate: { fingerprint256: 'AA:BB', validTo: validTo(-3) },
@@ -142,7 +142,7 @@ describe('analyseGatewayCertificateFactory', () => {
   it('should not report a closed port 80 on a node whose certificate is healthy', () => {
     // The port is only bound for the seconds a validation takes, so an external check finds it
     // closed on actively renewing nodes too. Alone it would fire far more often than it is right.
-    samples.setServiceInfo('gateway', 'acmeHttpPort', 'CLOSED');
+    samples.setServiceInfo('gateway', 'validationHttpPort', 'CLOSED');
 
     expect(analyse(served())).to.be.empty();
   });

--- a/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
@@ -81,7 +81,7 @@ describe('analyseGatewayCertificateFactory', () => {
 
     expect(problems).to.have.lengthOf(1);
     expect(problems[0].getDescription()).to.include('newer one is already present on disk');
-    expect(problems[0].getSolution()).to.include('dashmate restart');
+    expect(problems[0].getSolution()).to.include('dashmate restart --platform');
   });
 
   it('should warn before the outage when a renewed certificate has not been picked up', () => {

--- a/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
+++ b/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
@@ -1,5 +1,9 @@
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'fs';
+import os from 'node:os';
 import path from 'path';
+import tls from 'node:tls';
 import { Listr } from 'listr2';
 import getBaseConfigFactory from '../../../../../configs/defaults/getBaseConfigFactory.js';
 import HomeDir from '../../../../../src/config/HomeDir.js';
@@ -165,6 +169,70 @@ describe('collectSamplesTaskFactory', () => {
     expect(samples.getServiceInfo('gateway', 'ssl').error).to.be.undefined();
 
     expect(analyseConfig(samples)).to.be.empty();
+  });
+
+  it('should collect the certificate the gateway actually serves', async () => {
+    const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const key = privateKey.export({ type: 'pkcs8', format: 'pem' });
+
+    const certDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashmate-served-'));
+    const keyPath = path.join(certDir, 'key.pem');
+    const certPath = path.join(certDir, 'cert.pem');
+
+    fs.writeFileSync(keyPath, key);
+
+    execFileSync('openssl', [
+      'req', '-x509', '-new', '-key', keyPath, '-out', certPath,
+      '-subj', `/CN=${EXTERNAL_IP}`,
+      '-addext', `subjectAltName=IP:${EXTERNAL_IP}`,
+      '-addext', 'basicConstraints=CA:FALSE',
+      '-days', '30',
+    ], { stdio: 'ignore' });
+
+    const cert = fs.readFileSync(certPath, 'utf8');
+
+    const server = tls.createServer({ cert, key }, (socket) => socket.end());
+    const liveSockets = [];
+
+    server.on('secureConnection', (socket) => liveSockets.push(socket));
+
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    // The gateway's own bundle is the certificate the server presents, so disk and wire agree
+    fs.writeFileSync(
+      path.join(homeDir.joinPath(config.getName(), 'platform', 'gateway', 'ssl'), 'bundle.crt'),
+      cert,
+      'utf8',
+    );
+
+    config.set('platform.gateway.listeners.dapiAndDrive.port', server.address().port);
+
+    getCertificate.resolves(new Certificate({
+      id: 'certificate-id',
+      common_name: EXTERNAL_IP,
+      status: 'issued',
+      created: toZeroSslDate(daysFromNow(-1)),
+      expires: toZeroSslDate(daysFromNow(89)),
+    }));
+
+    try {
+      await collectSamples();
+    } finally {
+      liveSockets.forEach((socket) => socket.destroy());
+      await new Promise((resolve) => {
+        server.close(resolve);
+      });
+      fs.rmSync(certDir, { recursive: true, force: true });
+    }
+
+    const servedCertificate = samples.getServiceInfo('gateway', 'servedCertificate');
+
+    expect(servedCertificate.state).to.equal('served');
+    expect(servedCertificate.identityVerified).to.be.true();
+    expect(servedCertificate.matchesOnDisk).to.be.true();
+    expect(samples.getServiceInfo('gateway', 'acmeHttpPort')).to.equal('OPEN');
   });
 
   it('should collect metrics as text rather than an unresolved promise', async () => {

--- a/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
+++ b/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
@@ -47,6 +47,7 @@ describe('collectSamplesTaskFactory', () => {
   let config;
   let getCertificate;
   let collectSamplesTask;
+  let createCollectSamplesTask;
   let analyseConfig;
   let samples;
 
@@ -109,7 +110,7 @@ describe('collectSamplesTaskFactory', () => {
       masternode: this.sinon.stub().resolves({ result: {} }),
     };
 
-    collectSamplesTask = collectSamplesTaskFactory(
+    createCollectSamplesTask = (isHelper = false) => collectSamplesTaskFactory(
       dockerCompose,
       this.sinon.stub().returns(rpcClient),
       this.sinon.stub().resolves('127.0.0.1'),
@@ -119,7 +120,10 @@ describe('collectSamplesTaskFactory', () => {
       homeDir,
       validateZeroSslCertificateFactory(homeDir, getCertificate),
       this.sinon.stub().resolves({}),
+      isHelper,
     );
+
+    collectSamplesTask = createCollectSamplesTask();
 
     analyseConfig = analyseConfigFactory();
 
@@ -233,6 +237,28 @@ describe('collectSamplesTaskFactory', () => {
     expect(servedCertificate.identityVerified).to.be.true();
     expect(servedCertificate.matchesOnDisk).to.be.true();
     expect(samples.getServiceInfo('gateway', 'acmeHttpPort')).to.equal('OPEN');
+  });
+
+  it('should not probe the gateway from inside the helper container', async () => {
+    // dashmate is installed in the helper image, so the CLI can be run there. Loopback is the
+    // helper's own there, not the host's, and probing it would report a healthy gateway as
+    // unreachable. Recorded as skipped so it reads as unknown rather than as a problem.
+    collectSamplesTask = createCollectSamplesTask(true);
+
+    getCertificate.resolves(new Certificate({
+      id: 'certificate-id',
+      common_name: EXTERNAL_IP,
+      status: 'issued',
+      created: toZeroSslDate(daysFromNow(-1)),
+      expires: toZeroSslDate(daysFromNow(89)),
+    }));
+
+    await collectSamples();
+
+    const servedCertificate = samples.getServiceInfo('gateway', 'servedCertificate');
+
+    expect(servedCertificate.state).to.equal('skipped');
+    expect(servedCertificate.reason).to.equal('helper-context');
   });
 
   it('should collect metrics as text rather than an unresolved promise', async () => {

--- a/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
+++ b/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
@@ -1,0 +1,185 @@
+import fs from 'fs';
+import path from 'path';
+import { Listr } from 'listr2';
+import getBaseConfigFactory from '../../../../../configs/defaults/getBaseConfigFactory.js';
+import HomeDir from '../../../../../src/config/HomeDir.js';
+import analyseConfigFactory from '../../../../../src/doctor/analyse/analyseConfigFactory.js';
+import { SEVERITY } from '../../../../../src/doctor/Prescription.js';
+import Samples from '../../../../../src/doctor/Samples.js';
+import collectSamplesTaskFactory from '../../../../../src/listr/tasks/doctor/collectSamplesTaskFactory.js';
+import Certificate from '../../../../../src/ssl/zerossl/Certificate.js';
+import validateZeroSslCertificateFactory, { ERRORS as ZEROSSL_ERRORS } from '../../../../../src/ssl/zerossl/validateZeroSslCertificateFactory.js';
+import providers from '../../../../../src/status/providers.js';
+
+const EXTERNAL_IP = '198.51.100.7';
+
+/**
+ * Format a date the way the ZeroSSL API reports certificate dates
+ *
+ * @param {Date} date
+ * @return {string}
+ */
+function toZeroSslDate(date) {
+  const pad = (number) => String(number).padStart(2, '0');
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} `
+    + `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+/**
+ * @param {number} days
+ * @return {Date}
+ */
+function daysFromNow(days) {
+  const date = new Date();
+
+  date.setDate(date.getDate() + days);
+
+  return date;
+}
+
+describe('collectSamplesTaskFactory', () => {
+  let homeDir;
+  let config;
+  let getCertificate;
+  let collectSamplesTask;
+  let analyseConfig;
+  let samples;
+
+  /**
+   * Run the sample collection the same way the doctor command does: as a subtask
+   * of a parent list, so the parent's renderer applies.
+   *
+   * @return {Promise<void>}
+   */
+  async function collectSamples() {
+    const tasks = new Listr(
+      [{ task: () => collectSamplesTask(config) }],
+      { renderer: 'silent' },
+    );
+
+    await tasks.run({ samples });
+  }
+
+  beforeEach(function beforeEach() {
+    homeDir = HomeDir.createTemp();
+
+    config = getBaseConfigFactory()();
+
+    config.set('externalIp', EXTERNAL_IP);
+    config.set('platform.enable', true);
+    config.set('platform.gateway.ssl.enabled', true);
+    config.set('platform.gateway.ssl.provider', 'zerossl');
+    config.set('platform.gateway.ssl.providerConfigs.zerossl.apiKey', 'a'.repeat(32));
+    config.set('platform.gateway.ssl.providerConfigs.zerossl.id', 'b'.repeat(32));
+
+    // The ZeroSSL validator inspects the certificate files on disk
+    const sslDir = homeDir.joinPath(config.getName(), 'platform', 'gateway', 'ssl');
+
+    fs.mkdirSync(sslDir, { recursive: true });
+    fs.writeFileSync(path.join(sslDir, 'csr.pem'), 'csr', 'utf8');
+    fs.writeFileSync(path.join(sslDir, 'private.key'), 'private key', 'utf8');
+    fs.writeFileSync(path.join(sslDir, 'bundle.crt'), 'bundle', 'utf8');
+
+    getCertificate = this.sinon.stub();
+
+    this.sinon.stub(providers.mnowatch, 'checkPortStatus').resolves('OPEN');
+
+    this.sinon.stub(global, 'fetch').resolves({
+      json: async () => ({}),
+      text: async () => 'metrics_sample 1',
+    });
+
+    const dockerCompose = {
+      throwErrorIfNotInstalled: this.sinon.stub().resolves(),
+      inspectService: this.sinon.stub().resolves({}),
+      logs: this.sinon.stub().resolves({ out: '', err: '' }),
+    };
+
+    const rpcClient = {
+      getBestChainLock: this.sinon.stub().resolves({ result: {} }),
+      quorum: this.sinon.stub().resolves({ result: {} }),
+      getBlockchainInfo: this.sinon.stub().resolves({ result: {} }),
+      getPeerInfo: this.sinon.stub().resolves({ result: {} }),
+      mnsync: this.sinon.stub().resolves({ result: {} }),
+      masternode: this.sinon.stub().resolves({ result: {} }),
+    };
+
+    collectSamplesTask = collectSamplesTaskFactory(
+      dockerCompose,
+      this.sinon.stub().returns(rpcClient),
+      this.sinon.stub().resolves('127.0.0.1'),
+      this.sinon.stub().returns({ request: this.sinon.stub().resolves({}) }),
+      this.sinon.stub().resolves([]),
+      this.sinon.stub().resolves({}),
+      homeDir,
+      validateZeroSslCertificateFactory(homeDir, getCertificate),
+      this.sinon.stub().resolves({}),
+    );
+
+    analyseConfig = analyseConfigFactory();
+
+    samples = new Samples();
+  });
+
+  afterEach(() => {
+    homeDir.remove();
+  });
+
+  it('should report a problem for a ZeroSSL certificate that expired months ago', async () => {
+    const expiredAt = daysFromNow(-180);
+
+    getCertificate.resolves(new Certificate({
+      id: 'certificate-id',
+      common_name: EXTERNAL_IP,
+      status: 'issued',
+      created: toZeroSslDate(daysFromNow(-270)),
+      expires: toZeroSslDate(expiredAt),
+    }));
+
+    await collectSamples();
+
+    expect(samples.getServiceInfo('gateway', 'ssl').error)
+      .to.equal(ZEROSSL_ERRORS.CERTIFICATE_EXPIRES_SOON);
+
+    const problems = analyseConfig(samples);
+
+    const sslProblem = problems
+      .find((problem) => problem.getDescription().includes('ZeroSSL certificate expires at'));
+
+    expect(sslProblem).to.exist();
+    expect(sslProblem.getSeverity()).to.equal(SEVERITY.HIGH);
+  });
+
+  it('should not report a problem for a valid ZeroSSL certificate', async () => {
+    getCertificate.resolves(new Certificate({
+      id: 'certificate-id',
+      common_name: EXTERNAL_IP,
+      status: 'issued',
+      created: toZeroSslDate(daysFromNow(-1)),
+      expires: toZeroSslDate(daysFromNow(89)),
+    }));
+
+    await collectSamples();
+
+    expect(samples.getServiceInfo('gateway', 'ssl').error).to.be.undefined();
+
+    expect(analyseConfig(samples)).to.be.empty();
+  });
+
+  it('should collect metrics as text rather than an unresolved promise', async () => {
+    config.set('platform.gateway.metrics.enabled', true);
+
+    getCertificate.resolves(new Certificate({
+      id: 'certificate-id',
+      common_name: EXTERNAL_IP,
+      status: 'issued',
+      created: toZeroSslDate(daysFromNow(-1)),
+      expires: toZeroSslDate(daysFromNow(89)),
+    }));
+
+    await collectSamples();
+
+    expect(samples.getServiceInfo('gateway', 'metrics')).to.equal('metrics_sample 1');
+  });
+});

--- a/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
+++ b/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
@@ -1,12 +1,10 @@
-import { execFileSync } from 'node:child_process';
-import crypto from 'node:crypto';
 import fs from 'fs';
-import os from 'node:os';
 import path from 'path';
 import tls from 'node:tls';
 import { Listr } from 'listr2';
 import getBaseConfigFactory from '../../../../../configs/defaults/getBaseConfigFactory.js';
 import HomeDir from '../../../../../src/config/HomeDir.js';
+import createCertificateForTest from '../../../../../src/test/createCertificateForTest.js';
 import analyseConfigFactory from '../../../../../src/doctor/analyse/analyseConfigFactory.js';
 import { SEVERITY } from '../../../../../src/doctor/Prescription.js';
 import Samples from '../../../../../src/doctor/Samples.js';
@@ -172,24 +170,7 @@ describe('collectSamplesTaskFactory', () => {
   });
 
   it('should collect the certificate the gateway actually serves', async () => {
-    const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
-    const key = privateKey.export({ type: 'pkcs8', format: 'pem' });
-
-    const certDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashmate-served-'));
-    const keyPath = path.join(certDir, 'key.pem');
-    const certPath = path.join(certDir, 'cert.pem');
-
-    fs.writeFileSync(keyPath, key);
-
-    execFileSync('openssl', [
-      'req', '-x509', '-new', '-key', keyPath, '-out', certPath,
-      '-subj', `/CN=${EXTERNAL_IP}`,
-      '-addext', `subjectAltName=IP:${EXTERNAL_IP}`,
-      '-addext', 'basicConstraints=CA:FALSE',
-      '-days', '30',
-    ], { stdio: 'ignore' });
-
-    const cert = fs.readFileSync(certPath, 'utf8');
+    const { cert, key } = createCertificateForTest({ ip: EXTERNAL_IP, days: 30 });
 
     const server = tls.createServer({ cert, key }, (socket) => socket.end());
     const liveSockets = [];
@@ -224,7 +205,6 @@ describe('collectSamplesTaskFactory', () => {
       await new Promise((resolve) => {
         server.close(resolve);
       });
-      fs.rmSync(certDir, { recursive: true, force: true });
     }
 
     const servedCertificate = samples.getServiceInfo('gateway', 'servedCertificate');

--- a/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
+++ b/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
@@ -47,7 +47,6 @@ describe('collectSamplesTaskFactory', () => {
   let config;
   let getCertificate;
   let collectSamplesTask;
-  let createCollectSamplesTask;
   let analyseConfig;
   let samples;
 
@@ -110,7 +109,7 @@ describe('collectSamplesTaskFactory', () => {
       masternode: this.sinon.stub().resolves({ result: {} }),
     };
 
-    createCollectSamplesTask = (isHelper = false) => collectSamplesTaskFactory(
+    collectSamplesTask = collectSamplesTaskFactory(
       dockerCompose,
       this.sinon.stub().returns(rpcClient),
       this.sinon.stub().resolves('127.0.0.1'),
@@ -120,10 +119,7 @@ describe('collectSamplesTaskFactory', () => {
       homeDir,
       validateZeroSslCertificateFactory(homeDir, getCertificate),
       this.sinon.stub().resolves({}),
-      isHelper,
     );
-
-    collectSamplesTask = createCollectSamplesTask();
 
     analyseConfig = analyseConfigFactory();
 
@@ -237,28 +233,6 @@ describe('collectSamplesTaskFactory', () => {
     expect(servedCertificate.identityVerified).to.be.true();
     expect(servedCertificate.matchesOnDisk).to.be.true();
     expect(samples.getServiceInfo('gateway', 'acmeHttpPort')).to.equal('OPEN');
-  });
-
-  it('should not probe the gateway from inside the helper container', async () => {
-    // dashmate is installed in the helper image, so the CLI can be run there. Loopback is the
-    // helper's own there, not the host's, and probing it would report a healthy gateway as
-    // unreachable. Recorded as skipped so it reads as unknown rather than as a problem.
-    collectSamplesTask = createCollectSamplesTask(true);
-
-    getCertificate.resolves(new Certificate({
-      id: 'certificate-id',
-      common_name: EXTERNAL_IP,
-      status: 'issued',
-      created: toZeroSslDate(daysFromNow(-1)),
-      expires: toZeroSslDate(daysFromNow(89)),
-    }));
-
-    await collectSamples();
-
-    const servedCertificate = samples.getServiceInfo('gateway', 'servedCertificate');
-
-    expect(servedCertificate.state).to.equal('skipped');
-    expect(servedCertificate.reason).to.equal('helper-context');
   });
 
   it('should collect metrics as text rather than an unresolved promise', async () => {

--- a/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
+++ b/packages/dashmate/test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js
@@ -232,7 +232,7 @@ describe('collectSamplesTaskFactory', () => {
     expect(servedCertificate.state).to.equal('served');
     expect(servedCertificate.identityVerified).to.be.true();
     expect(servedCertificate.matchesOnDisk).to.be.true();
-    expect(samples.getServiceInfo('gateway', 'acmeHttpPort')).to.equal('OPEN');
+    expect(samples.getServiceInfo('gateway', 'validationHttpPort')).to.equal('OPEN');
   });
 
   it('should collect metrics as text rather than an unresolved promise', async () => {

--- a/packages/dashmate/test/unit/ssl/letsencrypt/validateLetsEncryptCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/ssl/letsencrypt/validateLetsEncryptCertificateFactory.spec.js
@@ -1,0 +1,108 @@
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import HomeDir from '../../../../src/config/HomeDir.js';
+import validateLetsEncryptCertificateFactory, { ERRORS } from '../../../../src/ssl/letsencrypt/validateLetsEncryptCertificateFactory.js';
+
+const EXTERNAL_IP = '198.51.100.7';
+const CONFIG_NAME = 'testnet';
+
+describe('validateLetsEncryptCertificateFactory', () => {
+  let homeDir;
+  let legoDir;
+  let sslDir;
+  let config;
+  let validateLetsEncryptCertificate;
+
+  /**
+   * @return {{cert: string, key: string}}
+   */
+  function issueCertificate() {
+    const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const key = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+    const dir = fs.mkdtempSync(path.join(homeDir.getPath(), 'issue-'));
+    const keyPath = path.join(dir, 'key.pem');
+    const certPath = path.join(dir, 'cert.pem');
+
+    fs.writeFileSync(keyPath, key);
+
+    execFileSync('openssl', [
+      'req', '-x509', '-new', '-key', keyPath, '-out', certPath,
+      '-subj', `/CN=${EXTERNAL_IP}`,
+      '-addext', `subjectAltName=IP:${EXTERNAL_IP}`,
+      '-addext', 'basicConstraints=CA:FALSE',
+      '-days', '60',
+    ], { stdio: 'ignore' });
+
+    return { cert: fs.readFileSync(certPath, 'utf8'), key };
+  }
+
+  beforeEach(function beforeEach() {
+    homeDir = HomeDir.createTemp();
+
+    legoDir = homeDir.joinPath(CONFIG_NAME, 'platform', 'gateway', 'lego', 'certificates');
+    sslDir = homeDir.joinPath(CONFIG_NAME, 'platform', 'gateway', 'ssl');
+
+    fs.mkdirSync(legoDir, { recursive: true });
+    fs.mkdirSync(sslDir, { recursive: true });
+
+    config = {
+      get: this.sinon.stub().callsFake((option) => ({
+        'platform.gateway.ssl.providerConfigs.letsencrypt.email': 'operator@example.com',
+        externalIp: EXTERNAL_IP,
+      }[option])),
+      getName: this.sinon.stub().returns(CONFIG_NAME),
+    };
+
+    validateLetsEncryptCertificate = validateLetsEncryptCertificateFactory(homeDir);
+  });
+
+  afterEach(() => homeDir.remove());
+
+  it('should expose the not-installed error so callers can match on it', () => {
+    expect(ERRORS.CERTIFICATE_NOT_INSTALLED).to.equal('CERTIFICATE_NOT_INSTALLED');
+  });
+
+  it('should report no problem when the issued certificate is the one the gateway uses', async () => {
+    const { cert, key } = issueCertificate();
+
+    fs.writeFileSync(path.join(legoDir, `${EXTERNAL_IP}.crt`), cert);
+    fs.writeFileSync(path.join(legoDir, `${EXTERNAL_IP}.key`), key);
+    fs.writeFileSync(path.join(sslDir, 'bundle.crt'), cert);
+    fs.writeFileSync(path.join(sslDir, 'private.key'), key);
+
+    const result = await validateLetsEncryptCertificate(config);
+
+    expect(result.error).to.be.undefined();
+  });
+
+  it('should report a renewed certificate that was never copied to the gateway', async () => {
+    // Renewal writes a new certificate and then installs it for the gateway. When the second
+    // step does not happen the node keeps serving the previous certificate until it expires,
+    // and every check based on the renewed file alone still reports the node as healthy.
+    const renewed = issueCertificate();
+    const previous = issueCertificate();
+
+    fs.writeFileSync(path.join(legoDir, `${EXTERNAL_IP}.crt`), renewed.cert);
+    fs.writeFileSync(path.join(legoDir, `${EXTERNAL_IP}.key`), renewed.key);
+    fs.writeFileSync(path.join(sslDir, 'bundle.crt'), previous.cert);
+    fs.writeFileSync(path.join(sslDir, 'private.key'), previous.key);
+
+    const result = await validateLetsEncryptCertificate(config);
+
+    expect(result.error).to.equal('CERTIFICATE_NOT_INSTALLED');
+  });
+
+  it('should report a certificate that was issued but never installed at all', async () => {
+    const { cert, key } = issueCertificate();
+
+    fs.writeFileSync(path.join(legoDir, `${EXTERNAL_IP}.crt`), cert);
+    fs.writeFileSync(path.join(legoDir, `${EXTERNAL_IP}.key`), key);
+
+    const result = await validateLetsEncryptCertificate(config);
+
+    expect(result.error).to.equal('CERTIFICATE_NOT_INSTALLED');
+  });
+});

--- a/packages/dashmate/test/unit/ssl/letsencrypt/validateLetsEncryptCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/ssl/letsencrypt/validateLetsEncryptCertificateFactory.spec.js
@@ -1,8 +1,7 @@
-import { execFileSync } from 'node:child_process';
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import HomeDir from '../../../../src/config/HomeDir.js';
+import createCertificateForTest from '../../../../src/test/createCertificateForTest.js';
 import validateLetsEncryptCertificateFactory, { ERRORS } from '../../../../src/ssl/letsencrypt/validateLetsEncryptCertificateFactory.js';
 
 const EXTERNAL_IP = '198.51.100.7';
@@ -15,29 +14,7 @@ describe('validateLetsEncryptCertificateFactory', () => {
   let config;
   let validateLetsEncryptCertificate;
 
-  /**
-   * @return {{cert: string, key: string}}
-   */
-  function issueCertificate() {
-    const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
-    const key = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
-
-    const dir = fs.mkdtempSync(path.join(homeDir.getPath(), 'issue-'));
-    const keyPath = path.join(dir, 'key.pem');
-    const certPath = path.join(dir, 'cert.pem');
-
-    fs.writeFileSync(keyPath, key);
-
-    execFileSync('openssl', [
-      'req', '-x509', '-new', '-key', keyPath, '-out', certPath,
-      '-subj', `/CN=${EXTERNAL_IP}`,
-      '-addext', `subjectAltName=IP:${EXTERNAL_IP}`,
-      '-addext', 'basicConstraints=CA:FALSE',
-      '-days', '60',
-    ], { stdio: 'ignore' });
-
-    return { cert: fs.readFileSync(certPath, 'utf8'), key };
-  }
+  const issueCertificate = () => createCertificateForTest({ ip: EXTERNAL_IP, days: 60 });
 
   beforeEach(function beforeEach() {
     homeDir = HomeDir.createTemp();

--- a/packages/dashmate/test/unit/ssl/probeServedCertificate.spec.js
+++ b/packages/dashmate/test/unit/ssl/probeServedCertificate.spec.js
@@ -1,54 +1,9 @@
-import { execFileSync } from 'node:child_process';
-import crypto from 'node:crypto';
-import fs from 'node:fs';
 import net from 'node:net';
-import os from 'node:os';
-import path from 'node:path';
 import tls from 'node:tls';
 import probeServedCertificate, { STATE } from '../../../src/ssl/probeServedCertificate.js';
+import createCertificateForTest from '../../../src/test/createCertificateForTest.js';
 
 const EXTERNAL_IP = '127.0.0.1';
-
-/**
- * Generate a certificate at test time rather than committing one: a committed certificate
- * expires and fails the suite on a date nobody chose.
- *
- * @param {Object} options
- * @return {{cert: string, key: string}}
- */
-function createCertificate({ ip = EXTERNAL_IP, days = 30 } = {}) {
-  const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
-
-  const key = privateKey.export({ type: 'pkcs8', format: 'pem' });
-
-  // Node cannot issue certificates, so shell out to the openssl that ships with the OS
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashmate-cert-'));
-  const keyPath = path.join(dir, 'key.pem');
-  const certPath = path.join(dir, 'cert.pem');
-
-  fs.writeFileSync(keyPath, key);
-
-  // notBefore is anchored to notAfter so an already-expired certificate still has a valid
-  // ordering rather than starting after it ends
-  const notAfter = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
-  const notBefore = new Date(notAfter.getTime() - 30 * 24 * 60 * 60 * 1000);
-  const stamp = (date) => date.toISOString().replace(/[-:T]/g, '').replace(/\.\d+Z$/, 'Z');
-
-  execFileSync('openssl', [
-    'req', '-x509', '-new', '-key', keyPath, '-out', certPath,
-    '-subj', `/CN=${ip}`,
-    '-addext', `subjectAltName=IP:${ip}`,
-    '-addext', 'basicConstraints=CA:FALSE',
-    '-not_before', stamp(notBefore),
-    '-not_after', stamp(notAfter),
-  ], { stdio: 'ignore' });
-
-  const cert = fs.readFileSync(certPath, 'utf8');
-
-  fs.rmSync(dir, { recursive: true, force: true });
-
-  return { cert, key: key.toString() };
-}
 
 describe('probeServedCertificate', () => {
   const servers = [];
@@ -93,7 +48,7 @@ describe('probeServedCertificate', () => {
   });
 
   it('should report the certificate the server actually serves', async () => {
-    const { cert, key } = createCertificate({ days: 30 });
+    const { cert, key } = createCertificateForTest({ days: 30 });
     const port = await listenTls({ cert, key });
 
     const result = await probeServedCertificate({ host: '127.0.0.1', port, externalIp: EXTERNAL_IP });
@@ -104,7 +59,7 @@ describe('probeServedCertificate', () => {
   });
 
   it('should complete the handshake and report an expired certificate', async () => {
-    const { cert, key } = createCertificate({ days: -5 });
+    const { cert, key } = createCertificateForTest({ days: -5 });
     const port = await listenTls({ cert, key });
 
     const result = await probeServedCertificate({ host: '127.0.0.1', port, externalIp: EXTERNAL_IP });
@@ -116,7 +71,7 @@ describe('probeServedCertificate', () => {
   it('should not fail identity for a certificate naming the external IP rather than the probed address', async () => {
     // The gateway is reached on loopback but its certificate names the node's public address.
     // Judging identity against the dialled address would fail every healthy node.
-    const { cert, key } = createCertificate({ ip: '198.51.100.7' });
+    const { cert, key } = createCertificateForTest({ ip: '198.51.100.7' });
     const port = await listenTls({ cert, key });
 
     const result = await probeServedCertificate({
@@ -130,7 +85,7 @@ describe('probeServedCertificate', () => {
   });
 
   it('should report an identity mismatch against the external IP', async () => {
-    const { cert, key } = createCertificate({ ip: '203.0.113.9' });
+    const { cert, key } = createCertificateForTest({ ip: '203.0.113.9' });
     const port = await listenTls({ cert, key });
 
     const result = await probeServedCertificate({
@@ -146,7 +101,7 @@ describe('probeServedCertificate', () => {
   it('should report identity separately from the chain verdict when both fail', async () => {
     // The socket surfaces only the first verification failure, so an expired certificate that
     // also names the wrong address would otherwise hide the mismatch until the expiry was fixed.
-    const { cert, key } = createCertificate({ ip: '203.0.113.9', days: -5 });
+    const { cert, key } = createCertificateForTest({ ip: '203.0.113.9', days: -5 });
     const port = await listenTls({ cert, key });
 
     const result = await probeServedCertificate({

--- a/packages/dashmate/test/unit/ssl/probeServedCertificate.spec.js
+++ b/packages/dashmate/test/unit/ssl/probeServedCertificate.spec.js
@@ -1,0 +1,214 @@
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import tls from 'node:tls';
+import probeServedCertificate, { STATE } from '../../../src/ssl/probeServedCertificate.js';
+
+const EXTERNAL_IP = '127.0.0.1';
+
+/**
+ * Generate a certificate at test time rather than committing one: a committed certificate
+ * expires and fails the suite on a date nobody chose.
+ *
+ * @param {Object} options
+ * @return {{cert: string, key: string}}
+ */
+function createCertificate({ ip = EXTERNAL_IP, days = 30 } = {}) {
+  const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+  const key = privateKey.export({ type: 'pkcs8', format: 'pem' });
+
+  // Node cannot issue certificates, so shell out to the openssl that ships with the OS
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashmate-cert-'));
+  const keyPath = path.join(dir, 'key.pem');
+  const certPath = path.join(dir, 'cert.pem');
+
+  fs.writeFileSync(keyPath, key);
+
+  // notBefore is anchored to notAfter so an already-expired certificate still has a valid
+  // ordering rather than starting after it ends
+  const notAfter = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+  const notBefore = new Date(notAfter.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const stamp = (date) => date.toISOString().replace(/[-:T]/g, '').replace(/\.\d+Z$/, 'Z');
+
+  execFileSync('openssl', [
+    'req', '-x509', '-new', '-key', keyPath, '-out', certPath,
+    '-subj', `/CN=${ip}`,
+    '-addext', `subjectAltName=IP:${ip}`,
+    '-addext', 'basicConstraints=CA:FALSE',
+    '-not_before', stamp(notBefore),
+    '-not_after', stamp(notAfter),
+  ], { stdio: 'ignore' });
+
+  const cert = fs.readFileSync(certPath, 'utf8');
+
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  return { cert, key: key.toString() };
+}
+
+describe('probeServedCertificate', () => {
+  const servers = [];
+  const sockets = [];
+
+  /**
+   * Track every accepted connection so a server can be closed without waiting on one that the
+   * test deliberately left open.
+   *
+   * @param {Server} server
+   * @return {Server}
+   */
+  function track(server) {
+    server.on('connection', (socket) => sockets.push(socket));
+    server.on('secureConnection', (socket) => sockets.push(socket));
+
+    servers.push(server);
+
+    return server;
+  }
+
+  /**
+   * @param {Object} tlsOptions
+   * @return {Promise<number>} listening port
+   */
+  async function listenTls(tlsOptions) {
+    const server = track(tls.createServer(tlsOptions, (socket) => socket.end()));
+
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    return server.address().port;
+  }
+
+  afterEach(async () => {
+    sockets.splice(0).forEach((socket) => socket.destroy());
+
+    await Promise.all(servers.splice(0).map((server) => new Promise((resolve) => {
+      server.close(resolve);
+    })));
+  });
+
+  it('should report the certificate the server actually serves', async () => {
+    const { cert, key } = createCertificate({ days: 30 });
+    const port = await listenTls({ cert, key });
+
+    const result = await probeServedCertificate({ host: '127.0.0.1', port, externalIp: EXTERNAL_IP });
+
+    expect(result.state).to.equal(STATE.SERVED);
+    expect(result.certificate.fingerprint256).to.match(/^[0-9A-F]{2}(:[0-9A-F]{2})+$/);
+    expect(new Date(result.certificate.validTo).getTime()).to.be.greaterThan(Date.now());
+  });
+
+  it('should complete the handshake and report an expired certificate', async () => {
+    const { cert, key } = createCertificate({ days: -5 });
+    const port = await listenTls({ cert, key });
+
+    const result = await probeServedCertificate({ host: '127.0.0.1', port, externalIp: EXTERNAL_IP });
+
+    expect(result.state).to.equal(STATE.SERVED);
+    expect(new Date(result.certificate.validTo).getTime()).to.be.lessThan(Date.now());
+  });
+
+  it('should not fail identity for a certificate naming the external IP rather than the probed address', async () => {
+    // The gateway is reached on loopback but its certificate names the node's public address.
+    // Judging identity against the dialled address would fail every healthy node.
+    const { cert, key } = createCertificate({ ip: '198.51.100.7' });
+    const port = await listenTls({ cert, key });
+
+    const result = await probeServedCertificate({
+      host: '127.0.0.1',
+      port,
+      externalIp: '198.51.100.7',
+    });
+
+    expect(result.state).to.equal(STATE.SERVED);
+    expect(result.identityVerified).to.be.true();
+  });
+
+  it('should report an identity mismatch against the external IP', async () => {
+    const { cert, key } = createCertificate({ ip: '203.0.113.9' });
+    const port = await listenTls({ cert, key });
+
+    const result = await probeServedCertificate({
+      host: '127.0.0.1',
+      port,
+      externalIp: '198.51.100.7',
+    });
+
+    expect(result.state).to.equal(STATE.SERVED);
+    expect(result.identityVerified).to.be.false();
+  });
+
+  it('should report identity separately from the chain verdict when both fail', async () => {
+    // The socket surfaces only the first verification failure, so an expired certificate that
+    // also names the wrong address would otherwise hide the mismatch until the expiry was fixed.
+    const { cert, key } = createCertificate({ ip: '203.0.113.9', days: -5 });
+    const port = await listenTls({ cert, key });
+
+    const result = await probeServedCertificate({
+      host: '127.0.0.1',
+      port,
+      externalIp: '198.51.100.7',
+    });
+
+    expect(result.chainVerified).to.be.false();
+    expect(result.identityVerified).to.be.false();
+  });
+
+  it('should report unreachable when nothing is listening', async () => {
+    const result = await probeServedCertificate({
+      host: '127.0.0.1',
+      // Port 1 is privileged and unused, so the connection is refused rather than answered
+      port: 1,
+      externalIp: EXTERNAL_IP,
+    });
+
+    expect(result.state).to.equal(STATE.UNREACHABLE);
+    expect(result.certificate).to.be.undefined();
+  });
+
+  it('should give up on a peer that accepts the connection and never completes the handshake', async () => {
+    const server = track(net.createServer(() => {}));
+
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    const result = await probeServedCertificate({
+      host: '127.0.0.1',
+      port: server.address().port,
+      externalIp: EXTERNAL_IP,
+      timeout: 300,
+    });
+
+    expect(result.state).to.equal(STATE.UNREACHABLE);
+    expect(result.reason).to.equal('ETIMEDOUT');
+  });
+
+  it('should give up on a peer that trickles data without completing the handshake', async () => {
+    // The socket's own timeout resets on every byte received, so a slow drip would keep the
+    // probe alive forever if the deadline were not independent of it.
+    const server = track(net.createServer((socket) => {
+      const interval = setInterval(() => socket.write('\0'), 50);
+      socket.on('close', () => clearInterval(interval));
+      socket.on('error', () => clearInterval(interval));
+    }));
+
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    const result = await probeServedCertificate({
+      host: '127.0.0.1',
+      port: server.address().port,
+      externalIp: EXTERNAL_IP,
+      timeout: 400,
+    });
+
+    expect(result.state).to.equal(STATE.UNREACHABLE);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A live scan of all 353 registered mainnet evonodes found **88 (25%) serving an expired TLS
certificate**, unreachable by any standards-compliant client. Some had been dark for over a
year. PoSe does not probe port 443, so those nodes keep their score at 0 and are paid on the
same cadence as healthy ones — the tooling was the only place this could surface, and it was
blind.

Two independent reasons it stayed invisible:

1. **`dashmate doctor` could not report a certificate problem for any provider.** Five defects
   stacked on top of each other, so no path reached the operator.
2. **Nothing ever checked what the gateway actually serves.** Every check was file-based or
   provider-API-based, so a certificate that renewed on disk but never reached Envoy — a missed
   reload, an un-copied bundle — read as perfectly healthy everywhere.

Related: #4354 (mainnet shielded wallet sync fails because the SDK bootstrap list dials dead
evonodes).

## What was done?
<!--- Describe your changes in detail -->

### Doctor could not report certificate problems at all (`analyseConfigFactory.js`, `collectSamplesTaskFactory.js`)

- `validateZeroSslCertificate` was not awaited, so `error`/`data` destructured off a Promise and
  were both `undefined` — ZeroSSL nodes never produced a problem, whatever their state.
- `{block.cyanBright}` is not a chalk style. The message table is one eagerly-built object
  literal, so this threw `Unknown Chalk style: block` for **every** certificate error of **every**
  provider, including Let's Encrypt renewal failures.
- Two ZeroSSL messages dereferenced `ssl?.data?.certificate.expires` / `.common_name` with the
  chaining stopping at `data`, throwing for any error raised before the certificate is fetched.
- `ZEROSSL_ERRORS` and `LETSENCRYPT_ERRORS` share `CERTIFICATE_EXPIRES_SOON`, so in one literal
  the later Let's Encrypt entry silently overwrote the ZeroSSL one. Messages are now grouped per
  provider and selected by the configured provider.
- Three metrics samples did not await `fetchTextOrError`, storing unresolved Promises that
  serialised into diagnostic archives as `{}`.

### Report what the gateway actually serves (new)

- `src/ssl/probeServedCertificate.js` — opens a TLS connection to the gateway's own listener and
  reports the certificate it presents. Identity is judged against `externalIp` rather than the
  address dialled, and separately from the chain verdict, because a connection surfaces only its
  first verification failure. Has an absolute deadline (the socket `timeout` option is an
  inactivity timer that does not close the connection) and flattens the peer certificate to plain
  values (a verified chain is circular and breaks JSON serialisation and the obfuscation pass).
- `src/ssl/readCertificateBundle.js` — reads the gateway bundle's server certificate via
  `crypto.X509Certificate`, skipping CA blocks so a reversed operator-supplied bundle is not
  compared against an intermediate.
- `src/doctor/analyse/analyseGatewayCertificateFactory.js` — reports: expired with renewal not
  reaching the gateway (restart) vs. renewal itself failing (helper logs); renewed but not picked
  up while still valid; untrusted chain; wrong address; gateway not answering TLS. Validity is
  judged against `samples.date`, not analysis time, so an archive opened days later does not
  report every 6-day certificate as dead.
- Inbound port 80 is collected and reported **only alongside a certificate problem**. The port is
  bound for the seconds a validation takes, so an external check finds it closed on healthy nodes
  too — in the scan, 52 valid, actively-renewing nodes looked identical to 4 expired ones.

### Renewal that never reaches the gateway

- `dashmate ssl obtain` wrote the certificate files and exited; only the helper's scheduled
  renewal signalled the gateway. It now reloads the gateway, skipping with a message when the
  gateway is not running.
- `validateLetsEncryptCertificateFactory.js` already computed `isCertificatePairInstalled` and
  never read it. Now returned as `CERTIFICATE_NOT_INSTALLED`.

### ZeroSSL remediation

Every message told operators to run `dashmate ssl obtain`, which renews with the provider already
configured. Whether that works depends on the operator's ZeroSSL plan, which dashmate cannot see,
so both renewing and switching to Let's Encrypt are offered, with the cost stated (IP certificates
are 6-day and auto-renewing). Where the ZeroSSL API explained the failure — exhausted limit,
unpaid invoice, rejected key — that explanation is now the description; an API failure carrying no
message was previously dropped entirely. Also corrects a suggestion to run
`dashmate ssl zerossl obtain`, which is not a command that exists.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

`yarn workspace dashmate test:unit` — **331 passing**, lint clean.

New/updated specs:

- `test/unit/ssl/probeServedCertificate.spec.js` — probe against real `tls.createServer`
  instances: served/expired certificates, identity judged against `externalIp` rather than the
  probed address, identity reported separately from the chain when both fail, and the degradation
  cases (nothing listening; a peer that accepts TCP and never handshakes; a peer that trickles
  bytes to keep an inactivity timer alive).
- `test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js` — one case per severity row
  including the negatives, plus judging expiry against sample-collection time and port 80 being
  silent on a healthy node.
- `test/unit/doctor/analyse/analyseConfigFactory.spec.js` — pins that every provider's certificate
  errors produce a problem rather than throwing, plus the ZeroSSL remediation content.
- `test/unit/listr/tasks/doctor/collectSamplesTaskFactory.spec.js` — end-to-end sample collection,
  including a real TLS server so the probe wiring is exercised.
- `test/unit/ssl/letsencrypt/validateLetsEncryptCertificateFactory.spec.js` — a renewed
  certificate that was never installed for the gateway.
- `test/unit/commands/ssl/obtain.spec.js` — gateway reload after obtaining, and skipped when the
  gateway is not running.

Every fix was written test-first and observed failing against the unfixed code before the fix
landed. Certificate fixtures are generated at test time rather than committed, so no test rots on
a date nobody chose.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None. `dashmate doctor` reports problems it previously could not; `dashmate ssl obtain` gains a
reload step. No configuration, schema, or wire format changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive gateway certificate diagnostics, including expiry, identity, trust-chain, reachability, and stale-certificate checks.
  - Added detection for certificates issued but not installed in the gateway.
  - Added validation comparing gateway-served certificates with certificates stored on disk.
  - Added clearer SSL troubleshooting guidance for Let’s Encrypt, ZeroSSL, and file-based certificates, including ACME port checks.

- **Improvements**
  - Automatically reloads a running gateway after successfully obtaining an SSL certificate.
  - SSL and metrics checks now complete more reliably during diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->