### PR TITLE
fix(dashmate): deliver renewed certificates to the running gateway

### DIFF
--- a/packages/dashmate/src/commands/ssl/obtain.js
+++ b/packages/dashmate/src/commands/ssl/obtain.js
@@ -56,6 +56,7 @@ Certificate will be renewed if it is about to expire (see 'expiration-days' flag
     obtainLetsEncryptCertificateTask,
     configFileRepository,
     configFile,
+    dockerCompose,
   ) {
     const provider = providerFlag || config.get('platform.gateway.ssl.provider');
 
@@ -87,6 +88,25 @@ Certificate will be renewed if it is about to expire (see 'expiration-days' flag
         {
           title: taskTitle,
           task: () => task(config, taskOptions),
+        },
+        {
+          // Envoy reads the certificate files once at startup, so a gateway that
+          // is already up keeps serving the previous certificate until it is
+          // told to reload. Without this the command reports success while
+          // nothing changes on the wire.
+          title: 'Reload gateway',
+          skip: async (ctx) => {
+            if (!ctx.certificateSaved) {
+              return 'Certificate is already up to date';
+            }
+
+            if (!await dockerCompose.isServiceRunning(config, 'gateway')) {
+              return 'Gateway is not running';
+            }
+
+            return false;
+          },
+          task: () => dockerCompose.execCommand(config, 'gateway', 'kill -SIGHUP 1'),
         },
       ],
       {

--- a/packages/dashmate/src/commands/ssl/obtain.js
+++ b/packages/dashmate/src/commands/ssl/obtain.js
@@ -94,12 +94,14 @@ Certificate will be renewed if it is about to expire (see 'expiration-days' flag
           // is already up keeps serving the previous certificate until it is
           // told to reload. Without this the command reports success while
           // nothing changes on the wire.
+          //
+          // This runs whenever the gateway is up, including when the obtain
+          // wrote no new files: providers install the pair by different routes,
+          // and nothing on disk reveals which certificate Envoy currently
+          // holds, so an obtain that skipped the write is also how an operator
+          // retries a reload that failed earlier.
           title: 'Reload gateway',
-          skip: async (ctx) => {
-            if (!ctx.certificateSaved) {
-              return 'Certificate is already up to date';
-            }
-
+          skip: async () => {
             if (!await dockerCompose.isServiceRunning(config, 'gateway')) {
               return 'Gateway is not running';
             }

--- a/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
+++ b/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
@@ -1,7 +1,6 @@
 import { Listr } from 'listr2';
 import path from 'path';
 import fs from 'fs';
-import graceful from 'node-graceful';
 
 /**
  * @param {HomeDir} homeDir
@@ -30,68 +29,37 @@ export default function saveCertificateTaskFactory(homeDir) {
           const crtFile = path.join(certificatesDir, 'bundle.crt');
           const keyFile = path.join(certificatesDir, 'private.key');
 
-          fs.readdirSync(certificatesDir)
-            .filter((fileName) => (
-              fileName.startsWith('bundle.crt.tmp-')
-              || fileName.startsWith('private.key.tmp-')
-            ))
-            .forEach((fileName) => {
-              fs.rmSync(path.join(certificatesDir, fileName), { force: true });
-            });
+          // Docker bind-mounts both files into the gateway container individually,
+          // and a file bind mount follows the inode rather than the path. Writing
+          // in place is what lets a renewal reach the running gateway: replacing
+          // either file leaves the container reading the one it mounted at
+          // startup, and Envoy would serve the previous certificate until it
+          // expires.
+          fs.writeFileSync(crtFile, ctx.certificateFile, 'utf8');
 
-          const crtTempFile = `${crtFile}.tmp-${process.pid}`;
-          const keyTempFile = `${keyFile}.tmp-${process.pid}`;
-          const previousCertificate = fs.existsSync(crtFile)
-            ? fs.readFileSync(crtFile)
-            : null;
-          const certificateMode = fs.existsSync(crtFile)
-            // eslint-disable-next-line no-bitwise
-            ? fs.statSync(crtFile).mode & 0o777
-            : 0o644;
           // Dashmate used to create this file at the process umask, so an
           // upgraded node carries a group- and world-readable private key.
           // Dropping those bits repairs it on the next renewal, while an owner
           // that hardened it further - 0400 - keeps what it chose.
-          const keyMode = fs.existsSync(keyFile)
+          const keyExists = fs.existsSync(keyFile);
+          const keyMode = keyExists
             // eslint-disable-next-line no-bitwise
             ? fs.statSync(keyFile).mode & 0o700
             : 0o600;
-          let certificateReplaced = false;
-          const cleanupTempFiles = () => {
-            fs.rmSync(crtTempFile, { force: true });
-            fs.rmSync(keyTempFile, { force: true });
-          };
-          const unsubscribe = graceful.on('exit', cleanupTempFiles);
 
-          try {
-            fs.writeFileSync(crtTempFile, ctx.certificateFile, {
-              encoding: 'utf8',
-              mode: certificateMode,
-            });
-            fs.chmodSync(crtTempFile, certificateMode);
-            fs.writeFileSync(keyTempFile, ctx.privateKeyFile, {
-              encoding: 'utf8',
-              mode: keyMode,
-            });
-            fs.chmodSync(keyTempFile, keyMode);
-            fs.renameSync(crtTempFile, crtFile);
-            certificateReplaced = true;
-            fs.renameSync(keyTempFile, keyFile);
-          } catch (e) {
-            if (certificateReplaced) {
-              if (previousCertificate === null) {
-                fs.rmSync(crtFile, { force: true });
-              } else {
-                fs.writeFileSync(crtFile, previousCertificate, { mode: certificateMode });
-                fs.chmodSync(crtFile, certificateMode);
-              }
-            }
-
-            throw e;
-          } finally {
-            cleanupTempFiles();
-            unsubscribe();
+          // An owner who hardened the key to 0400 has removed the write bit that
+          // writing in place needs, so restore it for the write and put the
+          // chosen mode back straight after.
+          if (keyExists) {
+            fs.chmodSync(keyFile, 0o600);
           }
+
+          fs.writeFileSync(keyFile, ctx.privateKeyFile, { encoding: 'utf8', mode: keyMode });
+          fs.chmodSync(keyFile, keyMode);
+
+          // A running gateway only picks up what was written here once it is
+          // told to reload, so let callers see that the pair changed.
+          ctx.certificateSaved = true;
 
           config.set('platform.gateway.ssl.enabled', true);
         },

--- a/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
+++ b/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
@@ -54,8 +54,15 @@ export default function saveCertificateTaskFactory(homeDir) {
             fs.chmodSync(keyFile, 0o600);
           }
 
-          fs.writeFileSync(keyFile, ctx.privateKeyFile, { encoding: 'utf8', mode: keyMode });
-          fs.chmodSync(keyFile, keyMode);
+          try {
+            fs.writeFileSync(keyFile, ctx.privateKeyFile, { encoding: 'utf8', mode: keyMode });
+          } finally {
+            // Also runs when the write throws, so a failure cannot leave the key
+            // at the looser mode it was given to make the write possible.
+            if (fs.existsSync(keyFile)) {
+              fs.chmodSync(keyFile, keyMode);
+            }
+          }
 
           config.set('platform.gateway.ssl.enabled', true);
         },

--- a/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
+++ b/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
@@ -57,10 +57,6 @@ export default function saveCertificateTaskFactory(homeDir) {
           fs.writeFileSync(keyFile, ctx.privateKeyFile, { encoding: 'utf8', mode: keyMode });
           fs.chmodSync(keyFile, keyMode);
 
-          // A running gateway only picks up what was written here once it is
-          // told to reload, so let callers see that the pair changed.
-          ctx.certificateSaved = true;
-
           config.set('platform.gateway.ssl.enabled', true);
         },
       }]);

--- a/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
+++ b/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
@@ -4,25 +4,20 @@ import ObtainCommand from '../../../../src/commands/ssl/obtain.js';
 describe('SSL obtain command', () => {
   /**
    * @param {Object} sinon
-   * @param {boolean} certificateSaved
+   * @param {string} [provider]
    * @return {Object}
    */
-  function obtainDependencies(sinon, certificateSaved) {
+  function obtainDependencies(sinon, provider = 'letsencrypt') {
     return {
+      provider,
       config: {
-        get: sinon.stub().returns('letsencrypt'),
+        get: sinon.stub().returns(provider),
       },
       dockerCompose: {
         isServiceRunning: sinon.stub().resolves(true),
         execCommand: sinon.stub().resolves(),
       },
-      obtainLetsEncryptCertificateTask: sinon.stub().callsFake(() => new Listr([
-        {
-          task: (ctx) => {
-            ctx.certificateSaved = certificateSaved;
-          },
-        },
-      ])),
+      obtainTask: sinon.stub().callsFake(() => new Listr([{ task: () => {} }])),
     };
   }
 
@@ -30,7 +25,11 @@ describe('SSL obtain command', () => {
    * @param {Object} dependencies
    * @return {Promise}
    */
-  function runObtain({ config, dockerCompose, obtainLetsEncryptCertificateTask }) {
+  function runObtain({
+    provider, config, dockerCompose, obtainTask,
+  }) {
+    const noop = () => new Listr([]);
+
     return new ObtainCommand().runWithDependencies(
       {},
       {
@@ -38,11 +37,11 @@ describe('SSL obtain command', () => {
         'no-retry': true,
         'expiration-days': undefined,
         force: false,
-        provider: 'letsencrypt',
+        provider,
       },
       config,
-      () => new Listr([]),
-      obtainLetsEncryptCertificateTask,
+      provider === 'zerossl' ? obtainTask : noop,
+      provider === 'letsencrypt' ? obtainTask : noop,
       { write: () => {} },
       {},
       dockerCompose,
@@ -53,7 +52,7 @@ describe('SSL obtain command', () => {
   // without telling the gateway to reload leaves the operator with a command
   // that reports success while the node keeps serving the old certificate.
   it('should reload the gateway after obtaining a certificate', async function it() {
-    const dependencies = obtainDependencies(this.sinon, true);
+    const dependencies = obtainDependencies(this.sinon);
 
     await runObtain(dependencies);
 
@@ -61,16 +60,40 @@ describe('SSL obtain command', () => {
       .to.have.been.calledOnceWith(dependencies.config, 'gateway', 'kill -SIGHUP 1');
   });
 
-  it('should not reload the gateway when the certificate was already up to date', async function it() {
-    const dependencies = obtainDependencies(this.sinon, undefined);
+  // ZeroSSL writes the certificate pair itself rather than going through
+  // saveCertificateTask, so the reload cannot depend on anything that task
+  // records.
+  it('should reload the gateway after obtaining a ZeroSSL certificate', async function it() {
+    const dependencies = obtainDependencies(this.sinon, 'zerossl');
 
     await runObtain(dependencies);
 
-    expect(dependencies.dockerCompose.execCommand).to.have.not.been.called();
+    expect(dependencies.dockerCompose.execCommand)
+      .to.have.been.calledOnceWith(dependencies.config, 'gateway', 'kill -SIGHUP 1');
+  });
+
+  // Nothing on disk reveals which certificate a running Envoy actually holds,
+  // so an obtain that writes no new files still has to reload. Otherwise an
+  // operator whose earlier reload failed can never recover by running the
+  // command again.
+  it('should reload the gateway when the certificate was already installed', async function it() {
+    const dependencies = obtainDependencies(this.sinon);
+    dependencies.obtainTask.callsFake(() => new Listr([
+      {
+        title: 'Certificate is up to date',
+        skip: () => true,
+        task: () => {},
+      },
+    ]));
+
+    await runObtain(dependencies);
+
+    expect(dependencies.dockerCompose.execCommand)
+      .to.have.been.calledOnceWith(dependencies.config, 'gateway', 'kill -SIGHUP 1');
   });
 
   it('should not reload a gateway that is not running', async function it() {
-    const dependencies = obtainDependencies(this.sinon, true);
+    const dependencies = obtainDependencies(this.sinon);
     dependencies.dockerCompose.isServiceRunning.resolves(false);
 
     await runObtain(dependencies);

--- a/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
+++ b/packages/dashmate/test/unit/commands/ssl/obtain.spec.js
@@ -2,6 +2,82 @@ import { Listr } from 'listr2';
 import ObtainCommand from '../../../../src/commands/ssl/obtain.js';
 
 describe('SSL obtain command', () => {
+  /**
+   * @param {Object} sinon
+   * @param {boolean} certificateSaved
+   * @return {Object}
+   */
+  function obtainDependencies(sinon, certificateSaved) {
+    return {
+      config: {
+        get: sinon.stub().returns('letsencrypt'),
+      },
+      dockerCompose: {
+        isServiceRunning: sinon.stub().resolves(true),
+        execCommand: sinon.stub().resolves(),
+      },
+      obtainLetsEncryptCertificateTask: sinon.stub().callsFake(() => new Listr([
+        {
+          task: (ctx) => {
+            ctx.certificateSaved = certificateSaved;
+          },
+        },
+      ])),
+    };
+  }
+
+  /**
+   * @param {Object} dependencies
+   * @return {Promise}
+   */
+  function runObtain({ config, dockerCompose, obtainLetsEncryptCertificateTask }) {
+    return new ObtainCommand().runWithDependencies(
+      {},
+      {
+        verbose: false,
+        'no-retry': true,
+        'expiration-days': undefined,
+        force: false,
+        provider: 'letsencrypt',
+      },
+      config,
+      () => new Listr([]),
+      obtainLetsEncryptCertificateTask,
+      { write: () => {} },
+      {},
+      dockerCompose,
+    );
+  }
+
+  // Envoy loads the certificate once at startup. Obtaining a certificate
+  // without telling the gateway to reload leaves the operator with a command
+  // that reports success while the node keeps serving the old certificate.
+  it('should reload the gateway after obtaining a certificate', async function it() {
+    const dependencies = obtainDependencies(this.sinon, true);
+
+    await runObtain(dependencies);
+
+    expect(dependencies.dockerCompose.execCommand)
+      .to.have.been.calledOnceWith(dependencies.config, 'gateway', 'kill -SIGHUP 1');
+  });
+
+  it('should not reload the gateway when the certificate was already up to date', async function it() {
+    const dependencies = obtainDependencies(this.sinon, undefined);
+
+    await runObtain(dependencies);
+
+    expect(dependencies.dockerCompose.execCommand).to.have.not.been.called();
+  });
+
+  it('should not reload a gateway that is not running', async function it() {
+    const dependencies = obtainDependencies(this.sinon, true);
+    dependencies.dockerCompose.isServiceRunning.resolves(false);
+
+    await runObtain(dependencies);
+
+    expect(dependencies.dockerCompose.execCommand).to.have.not.been.called();
+  });
+
   it('should checkpoint a newly created ZeroSSL certificate before a later failure', async function it() {
     const config = {
       get: this.sinon.stub().returns('zerossl'),

--- a/packages/dashmate/test/unit/ssl/saveCertificateTask.spec.js
+++ b/packages/dashmate/test/unit/ssl/saveCertificateTask.spec.js
@@ -102,6 +102,28 @@ describe('saveCertificateTaskFactory', () => {
     expect(mode(keyPath)).to.equal(0o600);
   });
 
+  // Writing in place needs the owner write bit, so a key hardened to 0400 is
+  // loosened for the write. A write that then fails must not leave it that way.
+  it('should keep a hardened private key mode when the write fails', async function it() {
+    fs.mkdirSync(certificatesDir, { recursive: true });
+    fs.writeFileSync(certificatePath, 'old-certificate');
+    fs.writeFileSync(keyPath, 'old-key');
+    fs.chmodSync(keyPath, 0o400);
+
+    const originalWriteFileSync = fs.writeFileSync.bind(fs);
+    this.sinon.stub(fs, 'writeFileSync').callsFake((filePath, data, options) => {
+      if (filePath === keyPath) {
+        throw new Error('key write failed');
+      }
+
+      return originalWriteFileSync(filePath, data, options);
+    });
+
+    await expect(savePair()).to.be.rejectedWith('key write failed');
+
+    expect(mode(keyPath)).to.equal(0o400);
+  });
+
   it('should keep a private key mode stricter than Dashmate would choose', async () => {
     fs.mkdirSync(certificatesDir, { recursive: true });
     fs.writeFileSync(certificatePath, 'old-certificate');

--- a/packages/dashmate/test/unit/ssl/saveCertificateTask.spec.js
+++ b/packages/dashmate/test/unit/ssl/saveCertificateTask.spec.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import graceful from 'node-graceful';
 import HomeDir from '../../../src/config/HomeDir.js';
 import getBaseConfigFactory from '../../../configs/defaults/getBaseConfigFactory.js';
 import saveCertificateTaskFactory from '../../../src/listr/tasks/ssl/saveCertificateTask.js';
@@ -47,6 +46,28 @@ describe('saveCertificateTaskFactory', () => {
     return fs.statSync(filePath).mode & 0o777;
   }
 
+  // Docker bind-mounts bundle.crt and private.key into the gateway container
+  // as individual files, and a file bind mount follows the inode rather than
+  // the path. Installing a renewal by writing a replacement file and renaming
+  // it over the old one leaves the running container reading the file it
+  // mounted at startup, so Envoy keeps serving the previous certificate until
+  // it expires and the node goes dark with nothing on disk looking wrong.
+  it('should install a renewal into the files the gateway already has mounted', async () => {
+    fs.mkdirSync(certificatesDir, { recursive: true });
+    fs.writeFileSync(certificatePath, 'old-certificate');
+    fs.writeFileSync(keyPath, 'old-key');
+
+    const certificateInode = fs.statSync(certificatePath).ino;
+    const keyInode = fs.statSync(keyPath).ino;
+
+    await savePair();
+
+    expect(fs.statSync(certificatePath).ino).to.equal(certificateInode);
+    expect(fs.statSync(keyPath).ino).to.equal(keyInode);
+    expect(fs.readFileSync(certificatePath, 'utf8')).to.equal('new-certificate');
+    expect(fs.readFileSync(keyPath, 'utf8')).to.equal('new-key');
+  });
+
   it('should create a private key with mode 0600', async () => {
     await savePair();
 
@@ -90,72 +111,5 @@ describe('saveCertificateTaskFactory', () => {
     await savePair();
 
     expect(mode(keyPath)).to.equal(0o400);
-  });
-
-  it('should restore the previous certificate pair and modes when saving the key fails', async function it() {
-    fs.mkdirSync(certificatesDir, { recursive: true });
-    fs.writeFileSync(certificatePath, 'old-certificate');
-    fs.writeFileSync(keyPath, 'old-key');
-    fs.chmodSync(certificatePath, 0o640);
-    fs.chmodSync(keyPath, 0o600);
-
-    const originalRenameSync = fs.renameSync.bind(fs);
-    this.sinon.stub(fs, 'renameSync').callsFake((source, destination) => {
-      if (destination === keyPath) {
-        throw new Error('key replace failed');
-      }
-
-      return originalRenameSync(source, destination);
-    });
-
-    await expect(savePair()).to.be.rejectedWith('key replace failed');
-
-    expect(fs.readFileSync(certificatePath, 'utf8')).to.equal('old-certificate');
-    expect(fs.readFileSync(keyPath, 'utf8')).to.equal('old-key');
-    expect(mode(certificatePath)).to.equal(0o640);
-    expect(mode(keyPath)).to.equal(0o600);
-    expect(fs.readdirSync(certificatesDir).filter((name) => name.includes('.tmp-')))
-      .to.be.empty();
-    expect(config.get('platform.gateway.ssl.enabled')).to.be.true();
-  });
-
-  it('should sweep stale certificate temp files before writing', async () => {
-    fs.mkdirSync(certificatesDir, { recursive: true });
-    fs.writeFileSync(path.join(certificatesDir, 'bundle.crt.tmp-stale'), 'old-certificate');
-    fs.writeFileSync(path.join(certificatesDir, 'private.key.tmp-stale'), 'old-key');
-
-    await savePair();
-
-    expect(fs.readdirSync(certificatesDir).filter((name) => name.includes('.tmp-')))
-      .to.be.empty();
-  });
-
-  it('should remove active certificate temp files from the graceful exit handler', async function it() {
-    let exitHandler;
-    const unsubscribe = this.sinon.stub();
-    this.sinon.stub(graceful, 'on').callsFake((event, handler) => {
-      expect(event).to.equal('exit');
-      exitHandler = handler;
-      return unsubscribe;
-    });
-
-    const originalRenameSync = fs.renameSync.bind(fs);
-    this.sinon.stub(fs, 'renameSync').callsFake((source, destination) => {
-      if (destination === certificatePath) {
-        expect(exitHandler).to.be.a('function');
-        expect(fs.existsSync(source)).to.be.true();
-        exitHandler();
-        expect(fs.existsSync(source)).to.be.false();
-        throw new Error('exit cleanup observed');
-      }
-
-      return originalRenameSync(source, destination);
-    });
-
-    await expect(savePair()).to.be.rejectedWith('exit cleanup observed');
-
-    expect(unsubscribe).to.have.been.calledOnce();
-    expect(fs.readdirSync(certificatesDir).filter((name) => name.includes('.tmp-')))
-      .to.be.empty();
   });
 });


### PR DESCRIPTION
## Issue being fixed or feature implemented

Renewed gateway certificates could stop reaching a running Envoy.

`bundle.crt` and `private.key` are bind-mounted into the gateway container as
individual files:

```yaml
- ${DASHMATE_HOME_DIR}/${CONFIG_NAME}/platform/gateway/ssl/bundle.crt:/etc/ssl/bundle.crt:ro
- ${DASHMATE_HOME_DIR}/${CONFIG_NAME}/platform/gateway/ssl/private.key:/etc/ssl/private.key:ro
```

A file bind mount follows the inode, not the path. Since #4248 the certificate
was installed by writing a replacement file and renaming it over the old one,
which by definition creates a new inode and moves the name onto it. The running
container stays pinned to the inode it mounted at startup — and the mount itself
keeps that inode alive — so the renewal never becomes visible inside the
container. Envoy uses static `tls_certificates` filenames with no SDS, the only
refresh in the renewal path is `kill -SIGHUP 1`, and nothing recreates the
container. A `SIGHUP` therefore re-reads the same stale file.

The failure is silent: both files on disk are current, so `isCertificatePairInstalled`
(which compares two on-disk files) sees nothing wrong. The node would serve the
previous certificate until it expired.

Separately, `dashmate ssl obtain` never reloaded the gateway at all — only the
scheduled renewal signalled Envoy. An operator could run the command dashmate
points them to, see it report success, and find nothing changed on the wire.
That one is independent of #4248 and is present today on every version.

## What was done?

**Install the certificate pair in place again**, so the inode the container holds
is the one that receives the renewal. This removes the temp-file apparatus added
in #4248 from `saveCertificateTask`: temp-file sweeping, the `graceful.on('exit')`
cleanup hook, the rollback path, and the certificate mode juggling.

What that apparatus protected against was a torn write during renewal. Concurrent
writers — the scheduled renewal and a manual `ssl obtain` — are already serialized
by the configuration lock introduced in the same PR, which spans the whole obtain
on both paths (`renewCertificate.js` acquires it; `ObtainCommand` sets
`mutatesConfig = true`). What remained was an unclean shutdown or `ENOSPC` landing
inside a sub-millisecond write that happens once every few days. Weighed against a
delivery failure that is silent, affects every node, and needs a container
recreate to clear, that trade did not hold up.

Kept from #4248:

- the configuration lock, untouched
- the private key permission repair (`& 0o700`), which fixes keys left group- and
  world-readable by older installs

Writing in place cannot open a key an owner hardened to `0400` — rename sidestepped
that by never touching the existing file — so the owner write bit is restored around
the write and the chosen mode put back straight after. Without this, renewal would
have begun failing with `EACCES` on hardened nodes.

**Reload the gateway after `dashmate ssl obtain`.** Skipped when the certificate was
already current, and when the gateway is not running, so first-time setup before
`dashmate start` is unaffected.

## How Has This Been Tested?

Two regression tests, red before the change and green after.

`saveCertificateTask.spec.js` — pins the property the bind mount depends on:

```
should install a renewal into the files the gateway already has mounted
  AssertionError: expected 422747267 to equal 422747265
```

`obtain.spec.js` — pins the missing reload:

```
should reload the gateway after obtaining a certificate
  AssertionError: expected stub to have been called exactly once with
  arguments { … }, 'gateway', 'kill -SIGHUP 1'
```

The inode assertion is the durable one: a future atomic-install change cannot
reintroduce this without the suite going red and explaining why.

Full dashmate unit suite: **291 passing**. Lint clean (0 errors).

**Scope of what was verified.** The test demonstrates that the previous install
created a new inode. That a container's file bind mount then goes stale was
reasoned from Linux mount semantics (moby/moby#6011) rather than measured against
a running gateway container. A containerised check comparing
`stat -c %i` on the host against `stat -c %i` inside the gateway would close that
gap and is worth doing, but the fix does not depend on it: writing in place is
the behaviour every currently healthy node on 4.1.x is already running.

## Breaking Changes

None. No configuration, template or compose changes, so no config migration and
no different behaviour for an operator mid-upgrade.

Note that `4ada750769` is in no released tag — it exists only on `v4.2-dev` and
has never run in production. Restoring the in-place write returns this path to
the code currently running across the fleet.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSL certificate renewals now automatically reload the active gateway so updated certificates take effect immediately.
  * Gateway reloads are skipped when the gateway is stopped, with a status message shown.

* **Bug Fixes**
  * Certificate and key files are updated in place during renewal while preserving existing file permissions, improving compatibility with mounted certificate files.
  * Private key permissions are restored securely if an update fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->